### PR TITLE
OpenSearch ssl_version

### DIFF
--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/config.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/config.py
@@ -27,7 +27,7 @@ def _es_config() -> Dict[str, Any]:
         return config
 
     # Include SSL settings if using https
-    config["ssl_version"] = ssl.TLSVersion.TLSv1_3  # type: ignore
+    config["ssl_version"] = ssl.PROTOCOL_SSLv23  # type: ignore
     config["verify_certs"] = os.getenv("ES_VERIFY_CERTS", "true").lower() != "false"  # type: ignore
 
     # Include CA Certificates if verifying certs


### PR DESCRIPTION
**Related Issue(s):**

- #199 

**Description:**
Changes the OpenSearch config `ssl_version` to the default `ssl.PROTOCOL_SSLv23`. All other options throw an unsupported protocol error. Source: https://opensearch-project.github.io/opensearch-py/_modules/opensearchpy/connection/http_urllib3.html

**PR Checklist:**

- [ x ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ x ] Tests pass (run `make test`)
- [ x ] Documentation has been updated to reflect changes, if applicable
- [ x ] Changes are added to the changelog