### PR TITLE
Don't overwrite links before persisting Item/Collection in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Do not overwrite links in Item and Collection objects before persisting in database [#210](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/issues/210)
+
 
 ## [v2.1.0]
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -37,7 +37,6 @@ from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.config import Settings
 from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
-from stac_fastapi.types.links import CollectionLinks
 from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.search import BaseSearchPostRequest
 from stac_fastapi.types.stac import Collection, Collections, Item, ItemCollection
@@ -731,10 +730,9 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             ConflictError: If the collection already exists.
         """
         base_url = str(kwargs["request"].base_url)
-        collection_links = CollectionLinks(
-            collection_id=collection["id"], base_url=base_url
-        ).create_links()
-        collection["links"] = collection_links
+        collection = self.database.collection_serializer.stac_to_db(
+            collection, base_url
+        )
         await self.database.create_collection(collection=collection)
 
         return CollectionSerializer.db_to_stac(collection, base_url)
@@ -767,11 +765,9 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             "collection_id", collection["id"]
         )
 
-        collection_links = CollectionLinks(
-            collection_id=collection["id"], base_url=base_url
-        ).create_links()
-        collection["links"] = collection_links
-
+        collection = self.database.collection_serializer.stac_to_db(
+            collection, base_url
+        )
         await self.database.update_collection(
             collection_id=collection_id, collection=collection
         )

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -60,11 +60,7 @@ class ItemSerializer(Serializer):
         Returns:
             stac_types.Item: The database-ready STAC item object.
         """
-        item_links = ItemLinks(
-            collection_id=stac_data["collection"],
-            item_id=stac_data["id"],
-            base_url=base_url,
-        ).create_links()
+        item_links = resolve_links(stac_data.get("links", []), base_url)
         stac_data["links"] = item_links
 
         now = now_to_rfc3339_str()
@@ -110,6 +106,24 @@ class ItemSerializer(Serializer):
 
 class CollectionSerializer(Serializer):
     """Serialization methods for STAC collections."""
+
+    @classmethod
+    def stac_to_db(
+        cls, collection: stac_types.Collection, base_url: str
+    ) -> stac_types.Collection:
+        """
+        Transform STAC Collection to database-ready STAC collection.
+
+        Args:
+            stac_data: the STAC Collection object to be transformed
+            base_url: the base URL for the STAC API
+
+        Returns:
+            stac_types.Collection: The database-ready STAC Collection object.
+        """
+        collection = deepcopy(collection)
+        collection["links"] = resolve_links(collection.get("links", []), base_url)
+        return collection
 
     @classmethod
     def db_to_stac(cls, collection: dict, base_url: str) -> stac_types.Collection:

--- a/stac_fastapi/tests/resources/test_collection.py
+++ b/stac_fastapi/tests/resources/test_collection.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 
 import pystac
@@ -163,3 +164,18 @@ async def test_pagination_collection(app_client, ctx, txn_client):
 
     # Confirm we have paginated through all collections
     assert collection_ids == ids
+
+
+@pytest.mark.asyncio
+async def test_links_collection(app_client, ctx, txn_client):
+    await delete_collections_and_items(txn_client)
+    collection = copy.deepcopy(ctx.collection)
+    collection["links"].append(
+        {"href": "https://landsat.usgs.gov/", "rel": "license", "type": "text/html"}
+    )
+    await create_collection(txn_client, collection=collection)
+    response = await app_client.get(f"/collections/{collection['id']}")
+    assert (
+        len([link for link in response.json()["links"] if link["rel"] == "license"])
+        == 1
+    )


### PR DESCRIPTION
**Related Issue(s):**

- #210 

**Description:**
Do not overwrite links when serializing Item and Collection objects before persisting them in the database. Implemented the `CollectionSerializer.stac_to_db()` method to handle this operation.
Also do not store inferred links in the database, they will be added when loading objects from the database with the `Serializer.db_to_stac()` method.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog