### PR TITLE
get_all_collections index fix

### DIFF
--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -359,7 +359,7 @@ class DatabaseLogic:
             search_body["search_after"] = search_after
 
         response = await self.client.search(
-            index="collections",
+            index=COLLECTIONS_INDEX,
             body=search_body,
         )
 


### PR DESCRIPTION

**Description:**

Fixing a bug in the OpenSearch `database_logic.py` `get_all_collections` where the index was hardcoded to "collections"

**PR Checklist:**

- [ x ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ x ] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog