### PR TITLE
Update pip-docker example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Updated the pip_docker example to use stac-fastapi.elasticsearch 2.1.0 and the elasticsearch 8.11.0 docker image. [#216](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/216)
+
 ### Fixed
 
 - URL encode next href: [#215](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/issues/215)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-# stac-fastapi-elasticsearch (sfes) deployment examples
+# stac-fastapi.elasticsearch (sfes) deployment examples
 
 ## Deploy sfes from pip in docker
 

--- a/examples/pip_docker/Dockerfile
+++ b/examples/pip_docker/Dockerfile
@@ -15,4 +15,4 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip install stac-fastapi.elasticsearch==1.1.0
+RUN pip install stac-fastapi.elasticsearch==2.1.0

--- a/examples/pip_docker/docker-compose.yml
+++ b/examples/pip_docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   elasticsearch:
     container_name: es-container
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION:-8.1.3}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION:-8.11.0}
     environment:
       ES_JAVA_OPTS: -Xms512m -Xmx1g
     volumes:


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

Updated the pip_docker example to use stac-fastapi.elasticsearch 2.1.0 and the elasticsearch 8.11.0 docker image.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog