### PR TITLE
Add API root path environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - use index templates for Collection and Item indices [#208](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/discussions/208)
 - Added API `title`, `version`, and `description` parameters from environment variables `STAC_FASTAPI_TITLE`, `STAC_FASTAPI_VERSION` and `STAC_FASTAPI_DESCRIPTION`, respectively. [#207](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/207)
-- Added a `STAC_FASTAPI_ROOT_PATH` environment variable to define the root path. Useful when working with an APi gateway or load balancer. [#221](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/221)
+- Added a `STAC_FASTAPI_ROOT_PATH` environment variable to define the root path. Useful when working with an API gateway or load balancer. [#221](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/221)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - use index templates for Collection and Item indices [#208](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/discussions/208)
 - Added API `title`, `version`, and `description` parameters from environment variables `STAC_FASTAPI_TITLE`, `STAC_FASTAPI_VERSION` and `STAC_FASTAPI_DESCRIPTION`, respectively. [#207](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/207)
+- Added a `STAC_FASTAPI_ROOT_PATH` environment variable to define the root path. Useful when working with an APi gateway or load balancer. [#221](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/221)
+
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ curl -X "POST" "http://localhost:8080/collections" \
 
 Note: this "Collections Transaction" behavior is not part of the STAC API, but may be soon.  
 
+## Configure the API
+
+By default the API title and description are set to `stac-fastapi-<backend>`. Change the API title and description from the default by setting the `STAC_FASTAPI_TITLE` and `STAC_FASTAPI_DESCRIPTION` environment variables, respectively.
+
+By default the API will read from and write to the `collections` and `items_<collection name>` indices. To change the API collections index and the items index prefix, change the `STAC_COLLECTIONS_INDEX` and `STAC_ITEMS_INDEX_PREFIX` environment variables.
+
+The application root path is left as the base url by default. If deploying to AWS Lambda with a Gateway API, you will need to define the app root path to be the same as the Gateway API stage name where you will deploy the API. The app root path can be defined with the `STAC_FASTAPI_ROOT_PATH` environment variable (`/v1`, for example)
 
 ## Collection pagination
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -75,6 +75,7 @@ api = StacApi(
     search_post_request_model=post_request_model,
 )
 app = api.app
+app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
 
 @app.on_event("startup")

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -75,6 +75,7 @@ api = StacApi(
     search_post_request_model=post_request_model,
 )
 app = api.app
+app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
 
 @app.on_event("startup")


### PR DESCRIPTION
**Related Issue(s):**

- #220 

**Description:**
This enables a user to define an API root path. This provides a workaround for the issue described [here](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/issues/220). The PR also includes a readme section about configuring the API environment variables.

**PR Checklist:**

- [ x ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ x ] Tests pass (run `make test`)
- [ x ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog