### PR TITLE
Default to use cerifi.where() to find the ca_certs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated the pip_docker example to use stac-fastapi.elasticsearch 2.1.0 and the elasticsearch 8.11.0 docker image. [#216](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/216)
 - Updated the Data Loader CLI tool to accept a base_url, a data directory, a custom collection id, and an option to use bulk insert. [#218](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/218)
+- Changed the default `ca_certs` value to use `certifi.where()` to find the installed certificate authority. [#222](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/222)
 
 ### Fixed
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/config.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/config.py
@@ -3,6 +3,8 @@ import os
 import ssl
 from typing import Any, Dict, Set
 
+import certifi
+
 from elasticsearch import AsyncElasticsearch, Elasticsearch  # type: ignore
 from stac_fastapi.types.config import ApiSettings
 
@@ -31,9 +33,7 @@ def _es_config() -> Dict[str, Any]:
 
     # Include CA Certificates if verifying certs
     if config["verify_certs"]:
-        config["ca_certs"] = os.getenv(
-            "CURL_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt"
-        )
+        config["ca_certs"] = os.getenv("CURL_CA_BUNDLE", certifi.where())
 
     # Handle authentication
     if (u := os.getenv("ES_USER")) and (p := os.getenv("ES_PASS")):

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/config.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/config.py
@@ -3,6 +3,7 @@ import os
 import ssl
 from typing import Any, Dict, Set
 
+import certifi
 from opensearchpy import AsyncOpenSearch, OpenSearch
 
 from stac_fastapi.types.config import ApiSettings
@@ -32,9 +33,7 @@ def _es_config() -> Dict[str, Any]:
 
     # Include CA Certificates if verifying certs
     if config["verify_certs"]:
-        config["ca_certs"] = os.getenv(
-            "CURL_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt"
-        )
+        config["ca_certs"] = os.getenv("CURL_CA_BUNDLE", certifi.where())
 
     # Handle authentication
     if (u := os.getenv("ES_USER")) and (p := os.getenv("ES_PASS")):


### PR DESCRIPTION
**Related Issue(s):**

- #214 

**Description:**
Changes the default `ca_certs`  value to use `certifi.where()` to find the installed certificate authority. Makes it more flexible I think.

**PR Checklist:**

- [ x ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ x ] Tests pass (run `make test`)
- [ x ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog