### PR TITLE
core create_item fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed `POST /collections/test-collection/items` returning an item with an empty links array.
+- Fixed `POST /collections/test-collection/items` returning an item with an empty links array [#236](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/236)
 
 ## [v2.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `POST /collections/test-collection/items` returning an item with an empty links array.
+
 ## [v2.3.0]
 
 ### Changed 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -677,7 +677,7 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         else:
             item = await self.database.prep_create_item(item=item, base_url=base_url)
             await self.database.create_item(item, refresh=kwargs.get("refresh", False))
-            return item
+            return ItemSerializer.db_to_stac(item, base_url)
 
     @overrides
     async def update_item(


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/issues/235

**Description:**
Fixed `POST /collections/test-collection/items` returning an item with an empty `links` array.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog