### PR TITLE
Always generate links for all searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed issue where searches return an empty `links` array [241](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241)
 
-
 ## [v2.4.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where searches return an empty `links` array [241](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241)
+
 
 ## [v2.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed issue where searches return an empty `links` array [241](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241)
+- Fixed issue where searches return an empty `links` array [#241](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241)
 
 ## [v2.4.0]
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -619,9 +619,7 @@ class CoreClient(AsyncBaseCoreClient):
             if maybe_count is not None:
                 context_obj["matched"] = maybe_count
 
-        links = []
-        if next_token:
-            links = await PagingLinks(request=request, next=next_token).get_links()
+        links = await PagingLinks(request=request, next=next_token).get_links()
 
         return ItemCollection(
             type="FeatureCollection",

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -318,9 +318,7 @@ class CoreClient(AsyncBaseCoreClient):
             if maybe_count is not None:
                 context_obj["matched"] = maybe_count
 
-        links = []
-        if next_token:
-            links = await PagingLinks(request=request, next=next_token).get_links()
+        links = await PagingLinks(request=request, next=next_token).get_links()
 
         return ItemCollection(
             type="FeatureCollection",

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -571,6 +571,15 @@ async def test_get_missing_item_collection(app_client):
 
 
 @pytest.mark.asyncio
+async def test_pagination_base_links(app_client, ctx):
+    """Test that a search query always contains basic links"""
+    page = await app_client.get(f"/collections/{ctx.item['collection']}/items")
+
+    page_data = page.json()
+    assert {"self", "root"}.issubset({link["rel"] for link in page_data["links"]})
+
+
+@pytest.mark.asyncio
 async def test_pagination_item_collection(app_client, ctx, txn_client):
     """Test item collection pagination links (paging extension)"""
     ids = [ctx.item["id"]]


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/Healy-Hyperspatial/stac-fastapi-mongo/issues/20

**Description:**
Always generate links for all searches, since now base links are generated on the request and no longer stored.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog