### PR TITLE
Paginated search queries now don't return a token on the last page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed issue where paginated search queries would return a `next_token` on the last page [243](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/243)
 - Fixed issue where searches return an empty `links` array [241](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241)
 
 ## [v2.4.0]

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -318,9 +318,7 @@ class CoreClient(AsyncBaseCoreClient):
             if maybe_count is not None:
                 context_obj["matched"] = maybe_count
 
-        links = []
-        if next_token:
-            links = await PagingLinks(request=request, next=next_token).get_links()
+        links = await PagingLinks(request=request, next=next_token).get_links()
 
         return ItemCollection(
             type="FeatureCollection",

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -599,7 +599,11 @@ class DatabaseLogic:
                     ",".join([str(x) for x in sort_array]).encode()
                 ).decode()
 
-        matched = es_response["hits"]["total"]["value"]
+        matched = (
+            es_response["hits"]["total"]["value"]
+            if es_response["hits"]["total"]["relation"] == "eq"
+            else None
+        )
         if count_task.done():
             try:
                 matched = count_task.result().get("count")

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -584,7 +584,6 @@ class DatabaseLogic:
         items = (hit["_source"] for hit in hits)
 
         next_token = None
-
         if matched > page * limit:
             if hits and (sort_array := hits[-1].get("sort")):
                 next_token = urlsafe_b64encode(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -552,12 +552,12 @@ class DatabaseLogic:
             NotFoundError: If the collections specified in `collection_ids` do not exist.
         """
         search_after = None
-        page = 1  # Default page number
+        page = 1
 
         if token:
             decoded_token = urlsafe_b64decode(token.encode()).decode().split(",")
-            search_after = decoded_token[:-1]  # Extract sort values from the token
-            page = int(decoded_token[-1]) + 1  # Extract previous page number from the token and increment for next page
+            search_after = decoded_token[:-1]
+            page = int(decoded_token[-1]) + 1
 
         query = search.query.to_dict() if search.query else None
 
@@ -573,19 +573,19 @@ class DatabaseLogic:
                 size=limit,
             )
         )
-        
+
         try:
             es_response = await search_task
         except exceptions.NotFoundError:
             raise NotFoundError(f"Collections '{collection_ids}' do not exist")
-        
+
         matched = es_response["hits"]["total"]["value"]
         hits = es_response["hits"]["hits"]
         items = (hit["_source"] for hit in hits)
 
         next_token = None
-        
-        if matched > page * limit:  # Check if there are more results beyond the current page
+
+        if matched > page * limit:
             if hits and (sort_array := hits[-1].get("sort")):
                 next_token = urlsafe_b64encode(
                     ",".join([str(x) for x in sort_array] + [str(page)]).encode()

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -563,8 +563,6 @@ class DatabaseLogic:
 
         max_result_window = stac_fastapi.types.search.Limit.le
 
-        print(max_result_window)
-
         size_limit = min(limit + 1, max_result_window)
 
         search_task = asyncio.create_task(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -560,17 +560,6 @@ class DatabaseLogic:
 
         index_param = indices(collection_ids)
 
-        print(">>>>>>>>>>>>>>>>>>>>>>>>>>")
-        index_settings = await self.client.indices.get_settings(index=index_param)
-        max_result_window = int(
-            index_settings[index_param]["settings"]["index"]["max_result_window"][
-                "max_result_window"
-            ]
-        )
-        print(max_result_window)
-        print(index_settings)
-        print(">>>>>>>>>>>>>>>>>>>>>>>>>>")
-
         max_result_window = 10000
 
         size_limit = min(limit + 1, max_result_window)

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -598,7 +598,7 @@ class DatabaseLogic:
                     ",".join([str(x) for x in sort_array]).encode()
                 ).decode()
 
-        matched = None
+        matched = es_response["hits"]["total"]["value"]
         if count_task.done():
             try:
                 matched = count_task.result().get("count")

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, List, Optional, Protocol, Tuple, Type, U
 import attr
 from elasticsearch_dsl import Q, Search
 
+import stac_fastapi.types.search
 from elasticsearch import exceptions, helpers  # type: ignore
 from stac_fastapi.core.extensions import filter
 from stac_fastapi.core.serializers import CollectionSerializer, ItemSerializer
@@ -560,7 +561,9 @@ class DatabaseLogic:
 
         index_param = indices(collection_ids)
 
-        max_result_window = 10000
+        max_result_window = stac_fastapi.types.search.Limit.le
+
+        print(max_result_window)
 
         size_limit = min(limit + 1, max_result_window)
 

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -590,7 +590,7 @@ class DatabaseLogic:
             search_after = decoded_token[:-1]
             page = int(decoded_token[-1]) + 1
         if search_after:
-            search_body["search_after"] = search_after + [page]
+            search_body["search_after"] = search_after
 
         search_body["sort"] = sort if sort else DEFAULT_SORT
 
@@ -612,14 +612,14 @@ class DatabaseLogic:
 
         hits = es_response["hits"]["hits"]
         items = (hit["_source"] for hit in hits)
-
         matched = es_response["hits"]["total"]["value"]
 
         next_token = None
-        if hits and (sort_array := hits[-1].get("sort")):
-            next_token = urlsafe_b64encode(
-                ",".join([str(x) for x in sort_array] + [str(page)]).encode()
-            ).decode()
+        if matched > page * limit:
+            if hits and (sort_array := hits[-1].get("sort")):
+                next_token = urlsafe_b64encode(
+                    ",".join([str(x) for x in sort_array] + [str(page)]).encode()
+                ).decode()
 
         return items, matched, next_token
 

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -631,7 +631,11 @@ class DatabaseLogic:
                     ",".join([str(x) for x in sort_array]).encode()
                 ).decode()
 
-        matched = es_response["hits"]["total"]["value"]
+        matched = (
+            es_response["hits"]["total"]["value"]
+            if es_response["hits"]["total"]["relation"] == "eq"
+            else None
+        )
         if count_task.done():
             try:
                 matched = count_task.result().get("count")

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -605,6 +605,14 @@ class DatabaseLogic:
             )
         )
 
+        count_task = asyncio.create_task(
+            self.client.count(
+                index=index_param,
+                ignore_unavailable=ignore_unavailable,
+                body=search.to_dict(count=True),
+            )
+        )
+
         try:
             es_response = await search_task
         except exceptions.NotFoundError:
@@ -612,7 +620,16 @@ class DatabaseLogic:
 
         hits = es_response["hits"]["hits"]
         items = (hit["_source"] for hit in hits)
+
         matched = es_response["hits"]["total"]["value"]
+        if es_response["hits"]["total"]["relation"] != "eq":
+            if count_task.done():
+                try:
+                    matched = count_task.result().get("count")
+                except Exception as e:
+                    logger.error(f"Count task failed: {e}")
+        else:
+            count_task.cancel()
 
         next_token = None
         if matched > page * limit:

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -630,7 +630,7 @@ class DatabaseLogic:
                     ",".join([str(x) for x in sort_array]).encode()
                 ).decode()
 
-        matched = None
+        matched = es_response["hits"]["total"]["value"]
         if count_task.done():
             try:
                 matched = count_task.result().get("count")

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -582,7 +582,7 @@ class DatabaseLogic:
         query = search.query.to_dict() if search.query else None
         if query:
             search_body["query"] = query
-        
+
         search_after = None
         page = 1
         if token:
@@ -591,7 +591,7 @@ class DatabaseLogic:
             page = int(decoded_token[-1]) + 1
         if search_after:
             search_body["search_after"] = search_after + [page]
-        
+
         search_body["sort"] = sort if sort else DEFAULT_SORT
 
         index_param = indices(collection_ids)

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -11,6 +11,7 @@ from opensearchpy.exceptions import TransportError
 from opensearchpy.helpers.query import Q
 from opensearchpy.helpers.search import Search
 
+import stac_fastapi.types.search
 from stac_fastapi.core import serializers
 from stac_fastapi.core.extensions import filter
 from stac_fastapi.core.utilities import bbox2polygon
@@ -594,7 +595,7 @@ class DatabaseLogic:
 
         index_param = indices(collection_ids)
 
-        max_result_window = 10000
+        max_result_window = stac_fastapi.types.search.Limit.le
 
         size_limit = min(limit + 1, max_result_window)
 

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -493,11 +493,8 @@ async def test_item_search_temporal_window_timezone_get(app_client, ctx):
     }
     resp = await app_client.get("/search", params=params)
     resp_json = resp.json()
-    next_link = next(link for link in resp_json["links"] if link["rel"] == "next")[
-        "href"
-    ]
-    resp = await app_client.get(next_link)
     assert resp.status_code == 200
+    assert resp_json["features"][0]["id"] == test_item["id"]
 
 
 @pytest.mark.asyncio

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -492,8 +492,8 @@ async def test_item_search_temporal_window_timezone_get(app_client, ctx):
         "datetime": f"{datetime_to_str(item_date_before)}/{datetime_to_str(item_date_after)}",
     }
     resp = await app_client.get("/search", params=params)
-    resp_json = resp.json()
     assert resp.status_code == 200
+    resp_json = resp.json()
     assert resp_json["features"][0]["id"] == test_item["id"]
 
 

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -654,8 +654,8 @@ async def test_pagination_token_idempotent(app_client, ctx, txn_client):
     # Ingest 5 items
     for _ in range(5):
         ctx.item["id"] = str(uuid.uuid4())
-    await create_item(txn_client, ctx.item)
-    ids.append(ctx.item["id"])
+        await create_item(txn_client, ctx.item)
+        ids.append(ctx.item["id"])
 
     page = await app_client.get("/search", params={"ids": ",".join(ids), "limit": 3})
     page_data = page.json()

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -587,18 +587,17 @@ async def test_pagination_item_collection(app_client, ctx, txn_client):
         await create_item(txn_client, item=ctx.item)
         ids.append(ctx.item["id"])
 
-    # Paginate through all 6 items with a limit of 1 (expecting 7 requests)
+    # Paginate through all 6 items with a limit of 1 (expecting 6 requests)
     page = await app_client.get(
         f"/collections/{ctx.item['collection']}/items", params={"limit": 1}
     )
 
     item_ids = []
-    idx = 0
-    for idx in range(100):
+    for idx in range(1, 100):
         page_data = page.json()
         next_link = list(filter(lambda link: link["rel"] == "next", page_data["links"]))
         if not next_link:
-            assert not page_data["features"]
+            assert idx == 6
             break
 
         assert len(page_data["features"]) == 1

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -626,10 +626,8 @@ async def test_pagination_post(app_client, ctx, txn_client):
     # Paginate through all 5 items with a limit of 1 (expecting 5 requests)
     request_body = {"ids": ids, "limit": 1}
     page = await app_client.post("/search", json=request_body)
-    idx = 0
     item_ids = []
-    for _ in range(100):
-        idx += 1
+    for idx in range(1, 100):
         page_data = page.json()
         next_link = list(filter(lambda link: link["rel"] == "next", page_data["links"]))
         if not next_link:
@@ -642,7 +640,7 @@ async def test_pagination_post(app_client, ctx, txn_client):
         page = await app_client.post("/search", json=request_body)
 
     # Our limit is 1, so we expect len(ids) number of requests before we run out of pages
-    assert idx == len(ids) + 1
+    assert idx == len(ids)
 
     # Confirm we have paginated through all items
     assert not set(item_ids) - set(ids)


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/issues/242

**Merge dependencie(s):**

- https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241

**Description:**
- Paginated search queries now don't return a token on the last page.
- Made some fixes to the respective tests. In particular `test_pagination_token_idempotent` had and indentation issue
- Improved `execute_search` to make use of  `es_response["hits"]["total"]["value"]`

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog