### PR TITLE
Add pagination test to verify the absence of a 'next' link on the last page of results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added 
 
-- A test to ensure that pagination correctly returns expected links, particularly verifying the absence of a 'next' link on the last page of results [#241](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241)
+- A test to ensure that pagination correctly returns expected links, particularly verifying the absence of a 'next' link on the last page of results [#244](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/244)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added 
+
+- A test to ensure that pagination correctly returns expected links, particularly verifying the absence of a 'next' link on the last page of results [#241](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241)
+
 ### Fixed
 
 - Fixed issue where searches return an empty `links` array [#241](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/241)


### PR DESCRIPTION
**Related Issue(s):**

- #242 

**Description:**

Added a test to ensure that pagination correctly returns expected links, particularly verifying the absence of a 'next' link on the last page of results.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog