### PR TITLE
Add symlinks to publish readme to pypi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Symlnks from project-specific readme files to main readme [#250](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/250)
+
 ## [v2.4.1]
 
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Symlnks from project-specific readme files to main readme [#250](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/250)
+- Symlinks from project-specific readme files to main readme [#250](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/250)
 
 ## [v2.4.1]
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="left">
   <img src="https://github.com/radiantearth/stac-site/raw/master/images/logo/stac-030-long.png" width=600>
   <p align="left"><b>Elasticsearch and Opensearch backends for the stac-fastapi project.</b></p>
+  <p align="left"><b>Featuring stac-fastapi.core for simplifying the creation and maintenance of custom STAC api backends.</b></p>
 </p>
 
   

--- a/stac_fastapi/core/README.md
+++ b/stac_fastapi/core/README.md
@@ -1,1 +1,1 @@
-# stac-fastapi core library for Elasticsearch and Opensearch backends
+../../README.md

--- a/stac_fastapi/elasticsearch/README.md
+++ b/stac_fastapi/elasticsearch/README.md
@@ -1,5 +1,1 @@
-# stac-fastapi-elasticsearch
-
-## Requirements
-
-The Elasticsearch backend requires **elasticsearch**.
+../../README.md

--- a/stac_fastapi/opensearch/README.md
+++ b/stac_fastapi/opensearch/README.md
@@ -1,5 +1,1 @@
-# stac-fastapi-opensearch 
-
-## Requirements
-
-The Opensearch backend requires **opensearch**.
+../../README.md


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**

Add symlinks from project-specific readme files to main readme. This will improve the pypi release page. https://pypi.org/project/stac-fastapi.elasticsearch/

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog