### PR TITLE
Repair API sort tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- API sort extension tests [#264](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/264)
+
 ## [v3.0.0a1]
 
 ### Changed

--- a/stac_fastapi/tests/api/test_api.py
+++ b/stac_fastapi/tests/api/test_api.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -248,8 +248,10 @@ async def test_app_sort_extension_get_asc(app_client, txn_client, ctx):
 
     another_item_date = datetime.strptime(
         first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
-    ) - timedelta(days=1)
-    second_item["properties"]["datetime"] = another_item_date.isoformat() + "Z"
+    ).replace(tzinfo=timezone.utc) - timedelta(days=1)
+    second_item["properties"]["datetime"] = another_item_date.isoformat().replace(
+        "+00:00", "Z"
+    )
 
     await create_item(txn_client, second_item)
 
@@ -268,8 +270,10 @@ async def test_app_sort_extension_get_desc(app_client, txn_client, ctx):
     second_item["id"] = "another-item"
     another_item_date = datetime.strptime(
         first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
-    ) - timedelta(days=1)
-    second_item["properties"]["datetime"] = another_item_date.isoformat() + "Z"
+    ).replace(tzinfo=timezone.utc) - timedelta(days=1)
+    second_item["properties"]["datetime"] = another_item_date.isoformat().replace(
+        "+00:00", "Z"
+    )
     await create_item(txn_client, second_item)
 
     resp = await app_client.get("/search?sortby=-properties.datetime")
@@ -287,8 +291,10 @@ async def test_app_sort_extension_post_asc(app_client, txn_client, ctx):
     second_item["id"] = "another-item"
     another_item_date = datetime.strptime(
         first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
-    ) - timedelta(days=1)
-    second_item["properties"]["datetime"] = another_item_date.isoformat() + "Z"
+    ).replace(tzinfo=timezone.utc) - timedelta(days=1)
+    second_item["properties"]["datetime"] = another_item_date.isoformat().replace(
+        "+00:00", "Z"
+    )
     await create_item(txn_client, second_item)
 
     params = {
@@ -310,8 +316,10 @@ async def test_app_sort_extension_post_desc(app_client, txn_client, ctx):
     second_item["id"] = "another-item"
     another_item_date = datetime.strptime(
         first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
-    ) - timedelta(days=1)
-    second_item["properties"]["datetime"] = another_item_date.isoformat() + "Z"
+    ).replace(tzinfo=timezone.utc) - timedelta(days=1)
+    second_item["properties"]["datetime"] = another_item_date.isoformat().replace(
+        "+00:00", "Z"
+    )
     await create_item(txn_client, second_item)
 
     params = {

--- a/stac_fastapi/tests/api/test_api.py
+++ b/stac_fastapi/tests/api/test_api.py
@@ -245,7 +245,6 @@ async def test_app_sort_extension_get_asc(app_client, txn_client, ctx):
 
     second_item = dict(first_item)
     second_item["id"] = "another-item"
-
     another_item_date = datetime.strptime(
         first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
     ).replace(tzinfo=timezone.utc) - timedelta(days=1)

--- a/stac_fastapi/tests/api/test_api.py
+++ b/stac_fastapi/tests/api/test_api.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -245,10 +245,11 @@ async def test_app_sort_extension_get_asc(app_client, txn_client, ctx):
 
     second_item = dict(first_item)
     second_item["id"] = "another-item"
-    another_item_date = first_item["properties"]["datetime"] - timedelta(days=1)
-    second_item["properties"]["datetime"] = another_item_date.isoformat().replace(
-        "+00:00", "Z"
-    )
+
+    another_item_date = datetime.strptime(
+        first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
+    ) - timedelta(days=1)
+    second_item["properties"]["datetime"] = another_item_date.isoformat() + "Z"
 
     await create_item(txn_client, second_item)
 
@@ -265,10 +266,10 @@ async def test_app_sort_extension_get_desc(app_client, txn_client, ctx):
 
     second_item = dict(first_item)
     second_item["id"] = "another-item"
-    another_item_date = first_item["properties"]["datetime"] - timedelta(days=1)
-    second_item["properties"]["datetime"] = another_item_date.isoformat().replace(
-        "+00:00", "Z"
-    )
+    another_item_date = datetime.strptime(
+        first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
+    ) - timedelta(days=1)
+    second_item["properties"]["datetime"] = another_item_date.isoformat() + "Z"
     await create_item(txn_client, second_item)
 
     resp = await app_client.get("/search?sortby=-properties.datetime")
@@ -284,10 +285,10 @@ async def test_app_sort_extension_post_asc(app_client, txn_client, ctx):
 
     second_item = dict(first_item)
     second_item["id"] = "another-item"
-    another_item_date = first_item["properties"]["datetime"] - timedelta(days=1)
-    second_item["properties"]["datetime"] = another_item_date.isoformat().replace(
-        "+00:00", "Z"
-    )
+    another_item_date = datetime.strptime(
+        first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
+    ) - timedelta(days=1)
+    second_item["properties"]["datetime"] = another_item_date.isoformat() + "Z"
     await create_item(txn_client, second_item)
 
     params = {
@@ -307,10 +308,10 @@ async def test_app_sort_extension_post_desc(app_client, txn_client, ctx):
 
     second_item = dict(first_item)
     second_item["id"] = "another-item"
-    another_item_date = first_item["properties"]["datetime"] - timedelta(days=1)
-    second_item["properties"]["datetime"] = another_item_date.isoformat().replace(
-        "+00:00", "Z"
-    )
+    another_item_date = datetime.strptime(
+        first_item["properties"]["datetime"], "%Y-%m-%dT%H:%M:%SZ"
+    ) - timedelta(days=1)
+    second_item["properties"]["datetime"] = another_item_date.isoformat() + "Z"
     await create_item(txn_client, second_item)
 
     params = {


### PR DESCRIPTION
**Related Issue(s):**

- #262 

**Description:**

Edit to four tests of the sort extension. The timezone `Z` character was not being included with the `.replace` command. So it was removed and `Z` is appended to the datetime string.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog