### PR TITLE
Queryables landing page and collection links

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -22,12 +22,17 @@ def load_collection(base_url, collection_id, data_dir):
     collection["id"] = collection_id
     try:
         resp = requests.post(f"{base_url}/collections", json=collection)
-        if resp.status_code == 200:
+        if resp.status_code == 200 or resp.status_code == 201:
             click.echo(f"Status code: {resp.status_code}")
             click.echo(f"Added collection: {collection['id']}")
         elif resp.status_code == 409:
             click.echo(f"Status code: {resp.status_code}")
             click.echo(f"Collection: {collection['id']} already exists")
+        else:
+            click.echo(f"Status code: {resp.status_code}")
+            click.echo(
+                f"Error writing {collection['id']} collection. Message: {resp.text}"
+            )
     except requests.ConnectionError:
         click.secho("Failed to connect", fg="red", err=True)
 

--- a/sample_data/collection.json
+++ b/sample_data/collection.json
@@ -1,6 +1,7 @@
 {
   "id":"sentinel-s2-l2a-cogs-test",
   "stac_version":"1.0.0",
+  "type": "Collection",
   "description":"Sentinel-2a and Sentinel-2b imagery, processed to Level 2A (Surface Reflectance) and converted to Cloud-Optimized GeoTIFFs",
   "links":[
       {"rel":"self","href":"https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"},

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -255,7 +255,9 @@ class CoreClient(AsyncBaseCoreClient):
         request = kwargs["request"]
         collection = await self.database.find_collection(collection_id=collection_id)
         return self.collection_serializer.db_to_stac(
-            collection=collection, request=request
+            collection=collection,
+            request=request,
+            extensions=[type(ext).__name__ for ext in self.extensions],
         )
 
     async def item_collection(
@@ -764,7 +766,11 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         request = kwargs["request"]
         collection = self.database.collection_serializer.stac_to_db(collection, request)
         await self.database.create_collection(collection=collection)
-        return CollectionSerializer.db_to_stac(collection, request)
+        return CollectionSerializer.db_to_stac(
+            collection,
+            request,
+            extensions=[type(ext).__name__ for ext in self.database.extensions],
+        )
 
     @overrides
     async def update_collection(
@@ -798,7 +804,11 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             collection_id=collection_id, collection=collection
         )
 
-        return CollectionSerializer.db_to_stac(collection, request)
+        return CollectionSerializer.db_to_stac(
+            collection,
+            request,
+            extensions=[type(ext).__name__ for ext in self.database.extensions],
+        )
 
     @overrides
     async def delete_collection(

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -218,7 +218,7 @@ class CoreClient(AsyncBaseCoreClient):
         token = request.query_params.get("token")
 
         collections, next_token = await self.database.get_all_collections(
-            token=token, limit=limit, base_url=base_url
+            token=token, limit=limit, request=request
         )
 
         links = [
@@ -252,10 +252,10 @@ class CoreClient(AsyncBaseCoreClient):
         Raises:
             NotFoundError: If the collection with the given id cannot be found in the database.
         """
-        base_url = str(kwargs["request"].base_url)
+        request = kwargs["request"]
         collection = await self.database.find_collection(collection_id=collection_id)
         return self.collection_serializer.db_to_stac(
-            collection=collection, base_url=base_url
+            collection=collection, request=request
         )
 
     async def item_collection(
@@ -761,12 +761,12 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             ConflictError: If the collection already exists.
         """
         collection = collection.model_dump(mode="json")
-        base_url = str(kwargs["request"].base_url)
+        request = kwargs["request"]
         collection = self.database.collection_serializer.stac_to_db(
-            collection, base_url
+            collection, request
         )
         await self.database.create_collection(collection=collection)
-        return CollectionSerializer.db_to_stac(collection, base_url)
+        return CollectionSerializer.db_to_stac(collection, request)
 
     @overrides
     async def update_collection(
@@ -793,16 +793,16 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         """
         collection = collection.model_dump(mode="json")
 
-        base_url = str(kwargs["request"].base_url)
+        request = kwargs["request"]
 
         collection = self.database.collection_serializer.stac_to_db(
-            collection, base_url
+            collection, request
         )
         await self.database.update_collection(
             collection_id=collection_id, collection=collection
         )
 
-        return CollectionSerializer.db_to_stac(collection, base_url)
+        return CollectionSerializer.db_to_stac(collection, request)
 
     @overrides
     async def delete_collection(

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -158,7 +158,7 @@ class CoreClient(AsyncBaseCoreClient):
             landing_page["links"].append(
                 {
                     # TODO: replace this with Relations.queryables.value,
-                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "rel": "queryables",
                     # TODO: replace this with MimeTypes.jsonschema,
                     "type": "application/schema+json",
                     "title": "Queryables",

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -162,10 +162,10 @@ class CoreClient(AsyncBaseCoreClient):
                     # TODO: replace this with MimeTypes.jsonschema,
                     "type": "application/schema+json",
                     "title": "Queryables",
-                    "href": urljoin(base_url, "queryables")
+                    "href": urljoin(base_url, "queryables"),
                 }
             )
-            
+
         collections = await self.all_collections(request=kwargs["request"])
         for collection in collections["collections"]:
             landing_page["links"].append(
@@ -762,9 +762,7 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         """
         collection = collection.model_dump(mode="json")
         request = kwargs["request"]
-        collection = self.database.collection_serializer.stac_to_db(
-            collection, request
-        )
+        collection = self.database.collection_serializer.stac_to_db(collection, request)
         await self.database.create_collection(collection=collection)
         return CollectionSerializer.db_to_stac(collection, request)
 
@@ -795,9 +793,7 @@ class TransactionsClient(AsyncBaseTransactionsClient):
 
         request = kwargs["request"]
 
-        collection = self.database.collection_serializer.stac_to_db(
-            collection, request
-        )
+        collection = self.database.collection_serializer.stac_to_db(collection, request)
         await self.database.update_collection(
             collection_id=collection_id, collection=collection
         )

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -153,6 +153,19 @@ class CoreClient(AsyncBaseCoreClient):
             conformance_classes=self.conformance_classes(),
             extension_schemas=[],
         )
+
+        if self.extension_is_enabled("FilterExtension"):
+            landing_page["links"].append(
+                {
+                    # TODO: replace this with Relations.queryables.value,
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    # TODO: replace this with MimeTypes.jsonschema,
+                    "type": "application/schema+json",
+                    "title": "Queryables",
+                    "href": urljoin(base_url, "queryables")
+                }
+            )
+            
         collections = await self.all_collections(request=kwargs["request"])
         for collection in collections["collections"]:
             landing_page["links"].append(

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -105,6 +105,32 @@ class BaseLinks:
             ]
 
         return links
+    
+@attr.s
+class CollectionLinks(BaseLinks):
+    """Create inferred links specific to collections."""
+
+    collection_id: str = attr.ib()
+
+    def link_parent(self) -> Dict[str, Any]:
+        """Create the `parent` link."""
+        return dict(rel=Relations.parent, type=MimeTypes.json.value, href=self.base_url)
+
+    def link_items(self) -> Dict[str, Any]:
+        """Create the `items` link."""
+        return dict(
+            rel="items",
+            type=MimeTypes.geojson.value,
+            href=urljoin(self.base_url, f"collections/{self.collection_id}/items"),
+        )
+
+    def link_queryables(self) -> Dict[str, Any]:
+        """create the `queryables` link."""
+        return dict(
+            rel="queryables",
+            type=MimeTypes.json.value,
+            href=urljoin(self.base_url, f"collections/{self.collection_id}/quaryables"),
+        )
 
 
 @attr.s

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -112,6 +112,7 @@ class CollectionLinks(BaseLinks):
     """Create inferred links specific to collections."""
 
     collection_id: str = attr.ib()
+    extensions: List[str] = attr.ib(default=attr.Factory(list))
 
     def link_parent(self) -> Dict[str, Any]:
         """Create the `parent` link."""
@@ -127,11 +128,16 @@ class CollectionLinks(BaseLinks):
 
     def link_queryables(self) -> Dict[str, Any]:
         """Create the `queryables` link."""
-        return dict(
-            rel="queryables",
-            type=MimeTypes.json.value,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}/quaryables"),
-        )
+        if "FilterExtension" in self.extensions:
+            return dict(
+                rel="queryables",
+                type=MimeTypes.json.value,
+                href=urljoin(
+                    self.base_url, f"collections/{self.collection_id}/queryables"
+                ),
+            )
+        else:
+            return None
 
 
 @attr.s

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -105,7 +105,8 @@ class BaseLinks:
             ]
 
         return links
-    
+
+
 @attr.s
 class CollectionLinks(BaseLinks):
     """Create inferred links specific to collections."""
@@ -125,7 +126,7 @@ class CollectionLinks(BaseLinks):
         )
 
     def link_queryables(self) -> Dict[str, Any]:
-        """create the `queryables` link."""
+        """Create the `queryables` link."""
         return dict(
             rel="queryables",
             type=MimeTypes.json.value,

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -137,7 +137,8 @@ class CollectionSerializer(Serializer):
 
         Args:
             collection (dict): The collection data in dictionary form, extracted from the database.
-            bstarlette.requests.Request: the API request
+            starlette.requests.Request: the API request
+            extensions: A list of the extension class names (`ext.__name__`) or all enabled STAC API extensions.
 
         Returns:
             stac_types.Collection: The STAC collection object.

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -4,12 +4,12 @@ from copy import deepcopy
 from typing import Any
 
 import attr
+from starlette.requests import Request
 
 from stac_fastapi.core.datetime_utils import now_to_rfc3339_str
-from stac_fastapi.types import stac as stac_types
 from stac_fastapi.core.models.links import CollectionLinks
+from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.links import ItemLinks, resolve_links
-from starlette.requests import Request
 
 
 @attr.s
@@ -111,20 +111,22 @@ class CollectionSerializer(Serializer):
 
     @classmethod
     def stac_to_db(
-        cls, collection: stac_types.Collection, base_url: str
+        cls, collection: stac_types.Collection, request: Request
     ) -> stac_types.Collection:
         """
         Transform STAC Collection to database-ready STAC collection.
 
         Args:
             stac_data: the STAC Collection object to be transformed
-            base_url: the base URL for the STAC API
+            starlette.requests.Request: the API request
 
         Returns:
             stac_types.Collection: The database-ready STAC Collection object.
         """
         collection = deepcopy(collection)
-        collection["links"] = resolve_links(collection.get("links", []), base_url)
+        collection["links"] = resolve_links(
+            collection.get("links", []), str(request.base_url)
+        )
         return collection
 
     @classmethod
@@ -133,7 +135,7 @@ class CollectionSerializer(Serializer):
 
         Args:
             collection (dict): The collection data in dictionary form, extracted from the database.
-            base_url (str): The base URL for the collection.
+            bstarlette.requests.Request: the API request
 
         Returns:
             stac_types.Collection: The STAC collection object.

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -1,7 +1,7 @@
 """Serializers."""
 import abc
 from copy import deepcopy
-from typing import Any
+from typing import Any, List, Optional
 
 import attr
 from starlette.requests import Request
@@ -130,7 +130,9 @@ class CollectionSerializer(Serializer):
         return collection
 
     @classmethod
-    def db_to_stac(cls, collection: dict, request: Request) -> stac_types.Collection:
+    def db_to_stac(
+        cls, collection: dict, request: Request, extensions: Optional[List[str]] = []
+    ) -> stac_types.Collection:
         """Transform database model to STAC collection.
 
         Args:
@@ -161,7 +163,7 @@ class CollectionSerializer(Serializer):
 
         # Create the collection links using CollectionLinks
         collection_links = CollectionLinks(
-            collection_id=collection_id, request=request
+            collection_id=collection_id, request=request, extensions=extensions
         ).create_links()
 
         # Add any additional links from the collection dictionary

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -7,7 +7,9 @@ import attr
 
 from stac_fastapi.core.datetime_utils import now_to_rfc3339_str
 from stac_fastapi.types import stac as stac_types
-from stac_fastapi.types.links import CollectionLinks, ItemLinks, resolve_links
+from stac_fastapi.core.models.links import CollectionLinks
+from stac_fastapi.types.links import ItemLinks, resolve_links
+from starlette.requests import Request
 
 
 @attr.s
@@ -126,7 +128,7 @@ class CollectionSerializer(Serializer):
         return collection
 
     @classmethod
-    def db_to_stac(cls, collection: dict, base_url: str) -> stac_types.Collection:
+    def db_to_stac(cls, collection: dict, request: Request) -> stac_types.Collection:
         """Transform database model to STAC collection.
 
         Args:
@@ -157,13 +159,13 @@ class CollectionSerializer(Serializer):
 
         # Create the collection links using CollectionLinks
         collection_links = CollectionLinks(
-            collection_id=collection_id, base_url=base_url
+            collection_id=collection_id, request=request
         ).create_links()
 
         # Add any additional links from the collection dictionary
         original_links = collection.get("links")
         if original_links:
-            collection_links += resolve_links(original_links, base_url)
+            collection_links += resolve_links(original_links, str(request.base_url))
         collection["links"] = collection_links
 
         # Return the stac_types.Collection object

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -59,6 +59,8 @@ extensions = [
     filter_extension,
 ]
 
+database_logic.extensions = [type(ext).__name__ for ext in extensions]
+
 post_request_model = create_post_request_model(extensions)
 
 api = StacApi(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterable, List, Optional, Protocol, Tuple, Type, U
 
 import attr
 from elasticsearch_dsl import Q, Search
+from starlette.requests import Request
 
 from elasticsearch import exceptions, helpers  # type: ignore
 from stac_fastapi.core.extensions import filter
@@ -315,7 +316,7 @@ class DatabaseLogic:
     """CORE LOGIC"""
 
     async def get_all_collections(
-        self, token: Optional[str], limit: int, base_url: str
+        self, token: Optional[str], limit: int, request: Request
     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
         """Retrieve a list of all collections from Elasticsearch, supporting pagination.
 
@@ -342,7 +343,7 @@ class DatabaseLogic:
         hits = response["hits"]["hits"]
         collections = [
             self.collection_serializer.db_to_stac(
-                collection=hit["_source"], base_url=base_url
+                collection=hit["_source"], request=request
             )
             for hit in hits
         ]

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -313,6 +313,8 @@ class DatabaseLogic:
         default=CollectionSerializer
     )
 
+    extensions: List[str] = attr.ib(default=attr.Factory(list))
+
     """CORE LOGIC"""
 
     async def get_all_collections(
@@ -343,7 +345,7 @@ class DatabaseLogic:
         hits = response["hits"]["hits"]
         collections = [
             self.collection_serializer.db_to_stac(
-                collection=hit["_source"], request=request
+                collection=hit["_source"], request=request, extensions=self.extensions
             )
             for hit in hits
         ]

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -59,6 +59,8 @@ extensions = [
     filter_extension,
 ]
 
+database_logic.extensions = [type(ext).__name__ for ext in extensions]
+
 post_request_model = create_post_request_model(extensions)
 
 api = StacApi(

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -334,6 +334,8 @@ class DatabaseLogic:
         default=serializers.CollectionSerializer
     )
 
+    extensions: List[str] = attr.ib(default=attr.Factory(list))
+
     """CORE LOGIC"""
 
     async def get_all_collections(
@@ -367,7 +369,7 @@ class DatabaseLogic:
         hits = response["hits"]["hits"]
         collections = [
             self.collection_serializer.db_to_stac(
-                collection=hit["_source"], request=request
+                collection=hit["_source"], request=request, extensions=self.extensions
             )
             for hit in hits
         ]

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -10,6 +10,7 @@ from opensearchpy import exceptions, helpers
 from opensearchpy.exceptions import TransportError
 from opensearchpy.helpers.query import Q
 from opensearchpy.helpers.search import Search
+from starlette.requests import Request
 
 from stac_fastapi.core import serializers
 from stac_fastapi.core.extensions import filter
@@ -20,7 +21,6 @@ from stac_fastapi.opensearch.config import (
 from stac_fastapi.opensearch.config import OpensearchSettings as SyncSearchSettings
 from stac_fastapi.types.errors import ConflictError, NotFoundError
 from stac_fastapi.types.stac import Collection, Item
-from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
 

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -20,6 +20,7 @@ from stac_fastapi.opensearch.config import (
 from stac_fastapi.opensearch.config import OpensearchSettings as SyncSearchSettings
 from stac_fastapi.types.errors import ConflictError, NotFoundError
 from stac_fastapi.types.stac import Collection, Item
+from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
 
@@ -336,7 +337,7 @@ class DatabaseLogic:
     """CORE LOGIC"""
 
     async def get_all_collections(
-        self, token: Optional[str], limit: int, base_url: str
+        self, token: Optional[str], limit: int, request: Request
     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
         """
         Retrieve a list of all collections from Opensearch, supporting pagination.
@@ -366,7 +367,7 @@ class DatabaseLogic:
         hits = response["hits"]["hits"]
         collections = [
             self.collection_serializer.db_to_stac(
-                collection=hit["_source"], base_url=base_url
+                collection=hit["_source"], request=request
             )
             for hit in hits
         ]

--- a/stac_fastapi/tests/conftest.py
+++ b/stac_fastapi/tests/conftest.py
@@ -58,6 +58,7 @@ class Context:
 
 class MockRequest:
     base_url = "http://test-server"
+    url = "http://test-server/test"
     query_params = {}
 
     def __init__(

--- a/stac_fastapi/tests/extensions/test_filter.py
+++ b/stac_fastapi/tests/extensions/test_filter.py
@@ -10,13 +10,31 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 @pytest.mark.asyncio
 async def test_filter_extension_landing_page_link(app_client, ctx):
-    resp = await app_client.get(
-       "/"
-    )
+    resp = await app_client.get("/")
     assert resp.status_code == 200
+
+    resp_json = resp.json()
+    keys = [link["rel"] for link in resp_json["links"]]
+
+    assert "queryables" in keys
+
+
+@pytest.mark.asyncio
+async def test_filter_extension_collection_link(app_client, load_test_data):
+    """Test creation and deletion of a collection"""
+    test_collection = load_test_data("test_collection.json")
+    test_collection["id"] = "test"
+
+    resp = await app_client.post("/collections", json=test_collection)
+    assert resp.status_code == 201
+
+    resp = await app_client.get(f"/collections/{test_collection['id']}")
     resp_json = resp.json()
     keys = [link["rel"] for link in resp_json["links"]]
     assert "queryables" in keys
+
+    resp = await app_client.delete(f"/collections/{test_collection['id']}")
+    assert resp.status_code == 204
 
 
 @pytest.mark.asyncio

--- a/stac_fastapi/tests/extensions/test_filter.py
+++ b/stac_fastapi/tests/extensions/test_filter.py
@@ -9,6 +9,17 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.mark.asyncio
+async def test_filter_extension_landing_page_link(app_client, ctx):
+    resp = await app_client.get(
+       "/"
+    )
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    keys = [link["rel"] for link in resp_json["links"]]
+    assert "queryables" in keys
+
+
+@pytest.mark.asyncio
 async def test_search_filters_post(app_client, ctx):
 
     filters = []


### PR DESCRIPTION
**Related Issue(s):**

- #260 

**Description:**

- Code to add the `queryables` link included in the Filter extension to the landing page and collections
- Only adds the `queryables` collection link when the Filter extension is enabled. It does this by passing an extensions list to the DatabaseLogic class. This could be used to have other conditions for when certain extensions are disabled/enabled in the app. please let me know if you have any suggestions for this approach
- Some improvements to `data_loader.py`

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog