### PR TITLE
Fix `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!make
 APP_HOST ?= 0.0.0.0
-EXTERNAL_APP_PORT ?= ${APP_PORT}
+EXTERNAL_APP_PORT ?= 8080
 
 ES_APP_PORT ?= 8080
 ES_HOST ?= docker.for.mac.localhost


### PR DESCRIPTION
**Description:**

`make test` references an undefined variable, `APP_PORT`, which causes the the `docker-compose` command's `-p` argument to be malformed:

```
docker-compose run -p  :8080 ...
                      ^--- missing the left-side port!
```

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog