### PR TITLE
Remove `actions/cache` in favor of `actions/setup-python` caching

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,14 +78,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Cache pipenv packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: 'pip'
+          cache-dependency-path: |
+            **/setup.py
 
       - name: Lint code
         if: ${{ matrix.python-version == 3.11 }}


### PR DESCRIPTION
**Description:**

Currently, all CI jobs emit warnings due to `actions/cache@v3`, which uses an old Node.js version ([recent example](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/actions/runs/10507540026)).

> ![image](https://github.com/user-attachments/assets/bd0ea622-1ff4-4d16-8762-69307a79d5f8)

However, on inspection, it appears that `actions/cache` is configured incorrectly:

* There are no lock files for it to hash, resulting in a blank portion in the cache key ([caches generated in CI](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/actions/caches)).

  > ![image](https://github.com/user-attachments/assets/9b980b18-d9df-49ae-9bc4-21223216b0bb)

* The comments in the YAML claim that it's caching for pipenv, but then caches the pip directory instead.

  > ![image](https://github.com/user-attachments/assets/3e45be98-0a69-4e25-ad80-a1ee8974d698)

Therefore, this PR rips out `actions/cache` in favor of the Python caching already supported by `actions/setup-python`.

If this merges, please close #284.


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
      _n/a_
- [ ] Documentation has been updated to reflect changes, if applicable
      _n/a_
- [ ] Changes are added to the changelog
      _n/a_
