### PR TITLE
Fix some pydantic 2.0 `DeprecationWarning`s

### DIFF
--- a/stac_fastapi/tests/clients/test_elasticsearch.py
+++ b/stac_fastapi/tests/clients/test_elasticsearch.py
@@ -200,9 +200,11 @@ async def test_create_item(ctx, core_client, txn_client):
     resp = await core_client.get_item(
         ctx.item["id"], ctx.item["collection"], request=MockRequest
     )
-    assert Item(**ctx.item).dict(
+    assert Item(**ctx.item).model_dump(
         exclude={"links": ..., "properties": {"created", "updated"}}
-    ) == Item(**resp).dict(exclude={"links": ..., "properties": {"created", "updated"}})
+    ) == Item(**resp).model_dump(
+        exclude={"links": ..., "properties": {"created", "updated"}}
+    )
 
 
 @pytest.mark.asyncio

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -804,7 +804,7 @@ async def test_field_extension_exclude_default_includes(app_client, ctx):
 async def test_search_intersects_and_bbox(app_client):
     """Test POST search intersects and bbox are mutually exclusive (core)"""
     bbox = [-118, 34, -117, 35]
-    geoj = Polygon.from_bounds(*bbox).dict(exclude_none=True)
+    geoj = Polygon.from_bounds(*bbox).model_dump(exclude_none=True)
     params = {"bbox": bbox, "intersects": geoj}
     resp = await app_client.post("/search", json=params)
     assert resp.status_code == 400


### PR DESCRIPTION
**Description:**

The test suite is throwing many `DeprecationWarning`s and `UserWarning`s.

This PR addresses only one class: a pydantic 2.0 `DeprecationWarning` caused by `.dict()` calls in the test suite itself.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog