### PR TITLE
Aggregation self link with collection specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Fixed the `self` link for the `/collections/{collection_id}/aggregations` endpoint. [#295](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/295)
 
 ## [v3.1.0] - 2024-09-02
 

--- a/stac_fastapi/core/stac_fastapi/core/extensions/aggregation.py
+++ b/stac_fastapi/core/stac_fastapi/core/extensions/aggregation.py
@@ -143,7 +143,7 @@ class EsAsyncAggregationClient(AsyncBaseAggregationClient):
                     {
                         "rel": "self",
                         "type": "application/json",
-                        "href": urljoin(collection_endpoint, "aggregations"),
+                        "href": urljoin(collection_endpoint + "/", "aggregations"),
                     },
                 ]
             )

--- a/stac_fastapi/tests/extensions/test_aggregation.py
+++ b/stac_fastapi/tests/extensions/test_aggregation.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import urlparse
 
 import pytest
 
@@ -68,6 +69,11 @@ async def test_get_collection_aggregations(app_client, ctx, load_test_data):
     resp = await app_client.get(f"/collections/{test_collection['id']}/aggregations")
     assert resp.status_code == 200
     assert len(resp.json()["aggregations"]) == 15
+    rj = resp.json()
+    href_self = urlparse(
+        next(link["href"] for link in rj["links"] if link["rel"] == "self")
+    )
+    assert href_self.path == f"/collections/{test_collection['id']}/aggregations"
 
     resp = await app_client.delete(f"/collections/{test_collection['id']}")
     assert resp.status_code == 204
@@ -86,6 +92,11 @@ async def test_post_collection_aggregations(app_client, ctx, load_test_data):
     resp = await app_client.post(f"/collections/{test_collection['id']}/aggregations")
     assert resp.status_code == 200
     assert len(resp.json()["aggregations"]) == 15
+    rj = resp.json()
+    href_self = urlparse(
+        next(link["href"] for link in rj["links"] if link["rel"] == "self")
+    )
+    assert href_self.path == f"/collections/{test_collection['id']}/aggregations"
 
     resp = await app_client.delete(f"/collections/{test_collection['id']}")
     assert resp.status_code == 204


### PR DESCRIPTION
**Related Issue(s):**
N/A

**Description:**
Fixes the `self` link in the response of the `/collections/{collection_id}/aggregations` request. The collection ID segment was missing in the URL because of the relative path URL construction.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog