### PR TITLE
Collection search draft

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/extensions/__init__.py
+++ b/stac_fastapi/core/stac_fastapi/core/extensions/__init__.py
@@ -1,5 +1,11 @@
 """elasticsearch extensions modifications."""
 
+from .collection_post_search import CollectionSearchPostExtension
 from .query import Operator, QueryableTypes, QueryExtension
 
-__all__ = ["Operator", "QueryableTypes", "QueryExtension"]
+__all__ = [
+    "Operator",
+    "QueryableTypes",
+    "QueryExtension",
+    "CollectionSearchPostExtension",
+]

--- a/stac_fastapi/core/stac_fastapi/core/extensions/collection_post_search.py
+++ b/stac_fastapi/core/stac_fastapi/core/extensions/collection_post_search.py
@@ -1,0 +1,90 @@
+"""Request model for the Aggregation extension."""
+
+from typing import List, Optional, Union
+
+import attr
+from fastapi import APIRouter, FastAPI
+from stac_pydantic.api.collections import Collections
+from stac_pydantic.shared import MimeTypes
+
+from stac_fastapi.api.models import GeoJSONResponse
+from stac_fastapi.api.routes import create_async_endpoint
+from stac_fastapi.extensions.core.collection_search import (
+    CollectionSearchExtension,
+    ConformanceClasses,
+)
+from stac_fastapi.extensions.core.collection_search.client import (
+    AsyncBaseCollectionSearchClient,
+    BaseCollectionSearchClient,
+)
+from stac_fastapi.extensions.core.collection_search.request import (
+    BaseCollectionSearchGetRequest,
+    BaseCollectionSearchPostRequest,
+)
+from stac_fastapi.types.config import ApiSettings
+
+
+@attr.s
+class CollectionSearchPostExtension(CollectionSearchExtension):
+    """Collection-Search Extension.
+
+    Extents the collection-search extension with an additional
+    POST - /collections endpoint
+
+    NOTE: the POST - /collections endpoint can be conflicting with the
+    POST /collections endpoint registered for the Transaction extension.
+
+    https://github.com/stac-api-extensions/collection-search
+
+    Attributes:
+        conformance_classes (list): Defines the list of conformance classes for
+            the extension
+    """
+
+    client: Union[
+        AsyncBaseCollectionSearchClient, BaseCollectionSearchClient
+    ] = attr.ib()
+    settings: ApiSettings = attr.ib()
+    conformance_classes: List[str] = attr.ib(
+        default=[ConformanceClasses.COLLECTIONSEARCH, ConformanceClasses.BASIS]
+    )
+    schema_href: Optional[str] = attr.ib(default=None)
+    router: APIRouter = attr.ib(factory=APIRouter)
+
+    GET: BaseCollectionSearchGetRequest = attr.ib(
+        default=BaseCollectionSearchGetRequest
+    )
+    POST: BaseCollectionSearchPostRequest = attr.ib(
+        default=BaseCollectionSearchPostRequest
+    )
+
+    def register(self, app: FastAPI) -> None:
+        """Register the extension with a FastAPI application.
+
+        Args:
+            app: target FastAPI application.
+
+        Returns:
+            None
+        """
+        self.router.prefix = app.state.router_prefix
+
+        self.router.add_api_route(
+            name="Collections searcb",
+            path="/collections-search",
+            methods=["POST"],
+            response_model=(
+                Collections if self.settings.enable_response_models else None
+            ),
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": Collections,
+                },
+            },
+            response_class=GeoJSONResponse,
+            endpoint=create_async_endpoint(self.client.post_all_collections, self.POST),
+        )
+        app.include_router(self.router)

--- a/stac_fastapi/core/stac_fastapi/core/models/__init__.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/__init__.py
@@ -1,1 +1,5 @@
 """stac_fastapi.elasticsearch.models module."""
+from .search import CollectionSearchPostRequest
+
+"""elasticsearch extensions modifications."""
+__all__ = ["CollectionSearchPostRequest"]

--- a/stac_fastapi/core/stac_fastapi/core/models/search.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/search.py
@@ -1,1 +1,35 @@
-"""Unused search model."""
+"""Search model."""
+
+from typing import List, Optional
+
+from stac_fastapi.extensions.core.collection_search.collection_search import (
+    BaseCollectionSearchPostRequest,
+)
+from stac_fastapi.types.search import BaseSearchPostRequest
+
+
+# CollectionSearchPostRequest model.
+class CollectionSearchPostRequest(
+    BaseCollectionSearchPostRequest, BaseSearchPostRequest
+):
+    """The CollectionSearchPostRequest class."""
+
+    query: Optional[str] = None
+    token: Optional[str] = None
+    fields: Optional[List[str]] = None
+    sortby: Optional[str] = None
+    intersects: Optional[str] = None
+    filter: Optional[str] = None
+    filter_lang: Optional[str] = None
+    q: Optional[str] = None
+
+    def __init__(self, **kwargs):
+        """Run the Constructor."""
+        super().__init__(**kwargs)
+        self.query = kwargs.get("query", None)
+        self.token = kwargs.get("token", None)
+        self.sortby = kwargs.get("sortby", None)
+        self.fields = kwargs.get("fields", None)
+        self.filter = kwargs.get("filter", None)
+        self.filter_lang = kwargs.get("filter-lang", None)
+        self.q = kwargs.get("q", None)

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -5,18 +5,20 @@ import os
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
 from stac_fastapi.core.core import (
+    AsyncCollectionSearchClient,
     BulkTransactionsClient,
     CoreClient,
     EsAsyncBaseFiltersClient,
     TransactionsClient,
 )
-from stac_fastapi.core.extensions import QueryExtension
+from stac_fastapi.core.extensions import CollectionSearchPostExtension, QueryExtension
 from stac_fastapi.core.extensions.aggregation import (
     EsAggregationExtensionGetRequest,
     EsAggregationExtensionPostRequest,
     EsAsyncAggregationClient,
 )
 from stac_fastapi.core.extensions.fields import FieldsExtension
+from stac_fastapi.core.models import CollectionSearchPostRequest
 from stac_fastapi.core.route_dependencies import get_route_dependencies
 from stac_fastapi.core.session import Session
 from stac_fastapi.elasticsearch.config import ElasticsearchSettings
@@ -25,7 +27,7 @@ from stac_fastapi.elasticsearch.database_logic import (
     create_collection_index,
     create_index_templates,
 )
-from stac_fastapi.extensions.core import (
+from stac_fastapi.extensions.core import (  # CollectionSearchExtension,; CollectionSearchPostExtension
     AggregationExtension,
     FilterExtension,
     FreeTextExtension,
@@ -53,7 +55,11 @@ aggregation_extension = AggregationExtension(
 aggregation_extension.POST = EsAggregationExtensionPostRequest
 aggregation_extension.GET = EsAggregationExtensionGetRequest
 
+collection_client = AsyncCollectionSearchClient(database=database_logic)
 search_extensions = [
+    CollectionSearchPostExtension(
+        POST=CollectionSearchPostRequest, client=collection_client, settings=settings
+    ),
     TransactionExtension(
         client=TransactionsClient(
             database=database_logic, session=session, settings=settings

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -485,7 +485,7 @@ class DatabaseLogic:
         return item["_source"]
 
     @staticmethod
-    def make_search():
+    def make_search(is_collection_search=False):
         """Database logic to create a Search instance."""
         return Search().sort(*DEFAULT_SORT)
 


### PR DESCRIPTION
**Related Issue(s):**

Hi, I'm using this branch to discuss about collection search which is an hot topic for me and I needed to sort it out as per this pull request.

I'm encountering the following problems:
- We still need to use the POST to create new Collection(s) but the incoming expexted body is different
- Incompatible with Transactional (how to have it working?)
 
[The pull request uses another endpoint to avoid the clash]

Questions:
- Why the specifications define a new endpoint to search for items: .../search  while for the collections we are overloading the /collections ?
- Do you have any working example about having both search and creation working at the same time?

**Description:**

This patch reduced code duplication and implements the same search capabilities that we have over items but over collections returning a standard (?) /collections search response with the result of the search in the collection index.

The collectionID list for now is simply ignored.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog