### PR TITLE
Rate limit implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `datetime_frequency_interval` parameter for `datetime_frequency` aggregation. [#294](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/294)
+- Added rate limiting functionality with configurable limits using environment variable `STAC_FASTAPI_RATE_LIMIT`, example: `500/minute`. [#303](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/303)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -387,4 +387,4 @@ Support for additional fields and new aggregations can be added in the associate
 
 ## Rate Limiting
 
-Rate limiting is an optional feature that can be enabled through the `STAC_FASTAPI_RATE_LIMIT` environment variable (example value: `500/minute`). Examples can be found and a more detailed explanation is provided in [examples/rate_limit](examples/rate_limit).
+Rate limiting is an optional feature that can be enabled through the `STAC_FASTAPI_RATE_LIMIT` environment variable (example value: `500/minute`). Examples can be found in [examples/rate_limit](examples/rate_limit).

--- a/README.md
+++ b/README.md
@@ -384,3 +384,7 @@ Available aggregations are:
 - geometry_geotile_grid_frequency ([geotile grid](https://opensearch.org/docs/latest/aggregations/bucket/geotile-grid/) on Item.geometry)
 
 Support for additional fields and new aggregations can be added in the associated `database_logic.py` file.
+
+## Rate Limiting
+
+Rate limiting is an optional feature that can be enabled through the `STAC_FASTAPI_RATE_LIMIT` environment variable (example value: `500/minute`). Examples can be found and a more detailed explanation is provided in [examples/rate_limit](examples/rate_limit).

--- a/README.md
+++ b/README.md
@@ -387,4 +387,4 @@ Support for additional fields and new aggregations can be added in the associate
 
 ## Rate Limiting
 
-Rate limiting is an optional feature that can be enabled through the `STAC_FASTAPI_RATE_LIMIT` environment variable (example value: `500/minute`). Examples can be found in [examples/rate_limit](examples/rate_limit).
+Rate limiting is an optional security feature that controls API request frequency on a remote address basis. It's enabled by setting the `STAC_FASTAPI_RATE_LIMIT` environment variable, e.g., `500/minute`. This limits each client to 500 requests per minute, helping prevent abuse and maintain API stability. Implementation examples are available in the [examples/rate_limit](examples/rate_limit) directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ES_USE_SSL=false
       - ES_VERIFY_CERTS=false
       - BACKEND=elasticsearch
+      - STAC_FASTAPI_RATE_LIMIT=2/5second
     ports:
       - "8080:8080"
     volumes:
@@ -54,6 +55,7 @@ services:
       - ES_USE_SSL=false
       - ES_VERIFY_CERTS=false
       - BACKEND=opensearch
+      - STAC_FASTAPI_RATE_LIMIT=200/minute
     ports:
       - "8082:8082"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ES_USE_SSL=false
       - ES_VERIFY_CERTS=false
       - BACKEND=elasticsearch
-      - STAC_FASTAPI_RATE_LIMIT=200/minute
+      - STAC_FASTAPI_RATE_LIMIT=500/minute
     ports:
       - "8080:8080"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ES_USE_SSL=false
       - ES_VERIFY_CERTS=false
       - BACKEND=elasticsearch
-      - STAC_FASTAPI_RATE_LIMIT=2/5second
+      - STAC_FASTAPI_RATE_LIMIT=200/minute
     ports:
       - "8080:8080"
     volumes:

--- a/examples/rate_limit/docker-compose.rate_limit.yml
+++ b/examples/rate_limit/docker-compose.rate_limit.yml
@@ -22,6 +22,7 @@ services:
       - ES_USE_SSL=false
       - ES_VERIFY_CERTS=false
       - BACKEND=elasticsearch
+      - STAC_FASTAPI_RATE_LIMIT=500/minute
     ports:
       - "8080:8080"
     volumes:

--- a/stac_fastapi/core/setup.py
+++ b/stac_fastapi/core/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     "pygeofilter==0.2.1",
     "typing_extensions==4.8.0",
     "jsonschema",
+    "slowapi==0.1.9",
 ]
 
 setup(

--- a/stac_fastapi/core/stac_fastapi/core/rate_limit.py
+++ b/stac_fastapi/core/stac_fastapi/core/rate_limit.py
@@ -1,0 +1,27 @@
+import os
+from fastapi import FastAPI, Request
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+import logging
+
+logger = logging.getLogger(__name__)
+
+limiter = Limiter(key_func=get_remote_address)
+
+def setup_rate_limit(app: FastAPI):
+    RATE_LIMIT = os.getenv("STAC_FASTAPI_RATE_LIMIT")
+    logger.info(f"Setting up rate limit with RATE_LIMIT={RATE_LIMIT}")
+    if RATE_LIMIT:
+        app.state.limiter = limiter
+        app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+        app.add_middleware(SlowAPIMiddleware)
+
+        @app.middleware("http")
+        @limiter.limit(RATE_LIMIT)
+        async def rate_limit_middleware(request: Request, call_next):
+            response = await call_next(request)
+            return response
+
+    logger.info("Rate limit setup complete")

--- a/stac_fastapi/core/stac_fastapi/core/rate_limit.py
+++ b/stac_fastapi/core/stac_fastapi/core/rate_limit.py
@@ -1,16 +1,21 @@
+"""Rate limiting middleware."""
+
+import logging
 import os
+
 from fastapi import FastAPI, Request
 from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-import logging
+from slowapi.util import get_remote_address
 
 logger = logging.getLogger(__name__)
 
 limiter = Limiter(key_func=get_remote_address)
 
+
 def setup_rate_limit(app: FastAPI):
+    """Set up rate limiting middleware."""
     RATE_LIMIT = os.getenv("STAC_FASTAPI_RATE_LIMIT")
     logger.info(f"Setting up rate limit with RATE_LIMIT={RATE_LIMIT}")
     if RATE_LIMIT:

--- a/stac_fastapi/core/stac_fastapi/core/rate_limit.py
+++ b/stac_fastapi/core/stac_fastapi/core/rate_limit.py
@@ -12,23 +12,24 @@ from slowapi.util import get_remote_address
 
 logger = logging.getLogger(__name__)
 
+
 def get_limiter(key_func=get_remote_address):
+    """Create and return a Limiter instance for rate limiting."""
     return Limiter(key_func=key_func)
 
+
 def setup_rate_limit(
-    app: FastAPI, 
-    rate_limit: Optional[str] = None, 
-    key_func=get_remote_address
+    app: FastAPI, rate_limit: Optional[str] = None, key_func=get_remote_address
 ):
     """Set up rate limiting middleware."""
     RATE_LIMIT = rate_limit or os.getenv("STAC_FASTAPI_RATE_LIMIT")
-    
+
     if not RATE_LIMIT:
         logger.info("Rate limiting is disabled")
         return
 
     logger.info(f"Setting up rate limit with RATE_LIMIT={RATE_LIMIT}")
-    
+
     limiter = get_limiter(key_func)
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -99,7 +99,7 @@ app = api.app
 app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
 # Add rate limit
-setup_rate_limit(app)
+setup_rate_limit(app, rate_limit=os.getenv("STAC_FASTAPI_RATE_LIMIT"))
 
 
 @app.on_event("startup")

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -1,6 +1,7 @@
 """FastAPI application."""
 
 import os
+from stac_fastapi.core.rate_limit import setup_rate_limit
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
@@ -97,6 +98,8 @@ api = StacApi(
 app = api.app
 app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
+# Add rate limit
+setup_rate_limit(app)
 
 @app.on_event("startup")
 async def _startup_event() -> None:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -1,7 +1,6 @@
 """FastAPI application."""
 
 import os
-from stac_fastapi.core.rate_limit import setup_rate_limit
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
@@ -18,6 +17,7 @@ from stac_fastapi.core.extensions.aggregation import (
     EsAsyncAggregationClient,
 )
 from stac_fastapi.core.extensions.fields import FieldsExtension
+from stac_fastapi.core.rate_limit import setup_rate_limit
 from stac_fastapi.core.route_dependencies import get_route_dependencies
 from stac_fastapi.core.session import Session
 from stac_fastapi.elasticsearch.config import ElasticsearchSettings
@@ -100,6 +100,7 @@ app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
 # Add rate limit
 setup_rate_limit(app)
+
 
 @app.on_event("startup")
 async def _startup_event() -> None:

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -1,7 +1,6 @@
 """FastAPI application."""
 
 import os
-from stac_fastapi.core.rate_limit import setup_rate_limit
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
@@ -18,6 +17,7 @@ from stac_fastapi.core.extensions.aggregation import (
     EsAsyncAggregationClient,
 )
 from stac_fastapi.core.extensions.fields import FieldsExtension
+from stac_fastapi.core.rate_limit import setup_rate_limit
 from stac_fastapi.core.route_dependencies import get_route_dependencies
 from stac_fastapi.core.session import Session
 from stac_fastapi.extensions.core import (
@@ -100,6 +100,7 @@ app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
 # Add rate limit
 setup_rate_limit(app)
+
 
 @app.on_event("startup")
 async def _startup_event() -> None:

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -99,7 +99,7 @@ app = api.app
 app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
 # Add rate limit
-setup_rate_limit(app)
+setup_rate_limit(app, rate_limit=os.getenv("STAC_FASTAPI_RATE_LIMIT"))
 
 
 @app.on_event("startup")

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -1,6 +1,7 @@
 """FastAPI application."""
 
 import os
+from stac_fastapi.core.rate_limit import setup_rate_limit
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
@@ -97,6 +98,8 @@ api = StacApi(
 app = api.app
 app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
+# Add rate limit
+setup_rate_limit(app)
 
 @app.on_event("startup")
 async def _startup_event() -> None:

--- a/stac_fastapi/tests/basic_auth/test_basic_auth.py
+++ b/stac_fastapi/tests/basic_auth/test_basic_auth.py
@@ -18,7 +18,7 @@ async def test_get_search_not_authenticated(app_client_basic_auth, ctx):
 
 @pytest.mark.asyncio
 async def test_post_search_authenticated(app_client_basic_auth, ctx):
-    """Test protected endpoint [POST /search] with reader auhtentication"""
+    """Test protected endpoint [POST /search] with reader authentication"""
     if not os.getenv("BASIC_AUTH"):
         pytest.skip()
     params = {"id": ctx.item["id"]}
@@ -34,7 +34,7 @@ async def test_post_search_authenticated(app_client_basic_auth, ctx):
 async def test_delete_resource_anonymous(
     app_client_basic_auth,
 ):
-    """Test protected endpoint [DELETE /collections/{collection_id}] without auhtentication"""
+    """Test protected endpoint [DELETE /collections/{collection_id}] without authentication"""
     if not os.getenv("BASIC_AUTH"):
         pytest.skip()
 

--- a/stac_fastapi/tests/conftest.py
+++ b/stac_fastapi/tests/conftest.py
@@ -224,7 +224,7 @@ async def app():
 
     post_request_model = create_post_request_model(search_extensions)
 
-    app = StacApi(
+    return StacApi(
         settings=settings,
         client=CoreClient(
             database=database,
@@ -236,8 +236,6 @@ async def app():
         search_get_request_model=create_get_request_model(search_extensions),
         search_post_request_model=post_request_model,
     ).app
-
-    return app
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/stac_fastapi/tests/conftest.py
+++ b/stac_fastapi/tests/conftest.py
@@ -24,8 +24,8 @@ from stac_fastapi.core.extensions.aggregation import (
     EsAggregationExtensionPostRequest,
     EsAsyncAggregationClient,
 )
-from stac_fastapi.core.route_dependencies import get_route_dependencies
 from stac_fastapi.core.rate_limit import setup_rate_limit
+from stac_fastapi.core.route_dependencies import get_route_dependencies
 
 if os.getenv("BACKEND", "elasticsearch").lower() == "opensearch":
     from stac_fastapi.opensearch.config import AsyncOpensearchSettings as AsyncSettings
@@ -243,9 +243,9 @@ async def app():
 @pytest_asyncio.fixture(scope="function")
 async def app_rate_limit(monkeypatch):
     monkeypatch.setenv("STAC_FASTAPI_RATE_LIMIT", "2/minute")
-    
+
     settings = AsyncSettings()
-    
+
     aggregation_extension = AggregationExtension(
         client=EsAsyncAggregationClient(
             database=database, session=None, settings=settings
@@ -290,7 +290,6 @@ async def app_rate_limit(monkeypatch):
     setup_rate_limit(app)
 
     return app
-
 
 
 @pytest_asyncio.fixture(scope="session")

--- a/stac_fastapi/tests/conftest.py
+++ b/stac_fastapi/tests/conftest.py
@@ -292,9 +292,7 @@ async def app_rate_limit():
     ).app
 
     # Set up rate limit
-    os.environ["STAC_FASTAPI_RATE_LIMIT"] = "2/minute"
-    setup_rate_limit(app)
-    del os.environ["STAC_FASTAPI_RATE_LIMIT"]
+    setup_rate_limit(app, rate_limit="2/minute")
 
     return app
 

--- a/stac_fastapi/tests/rate_limit/test_rate_limit.py
+++ b/stac_fastapi/tests/rate_limit/test_rate_limit.py
@@ -1,0 +1,20 @@
+import pytest
+from httpx import AsyncClient
+import logging
+from slowapi.errors import RateLimitExceeded
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+async def test_rate_limit(app_client_rate_limit: AsyncClient):
+    expected_status_codes = [200, 200, 429, 429, 429]
+    
+    for i, expected_status_code in enumerate(expected_status_codes):
+        try:
+            response = await app_client_rate_limit.get("/collections")
+            status_code = response.status_code
+        except RateLimitExceeded:
+            status_code = 429
+        
+        logger.info(f"Request {i+1}: Status code {status_code}")
+        assert status_code == expected_status_code, f"Expected status code {expected_status_code}, but got {status_code}"

--- a/stac_fastapi/tests/rate_limit/test_rate_limit.py
+++ b/stac_fastapi/tests/rate_limit/test_rate_limit.py
@@ -1,20 +1,24 @@
+import logging
+
 import pytest
 from httpx import AsyncClient
-import logging
 from slowapi.errors import RateLimitExceeded
 
 logger = logging.getLogger(__name__)
 
+
 @pytest.mark.asyncio
 async def test_rate_limit(app_client_rate_limit: AsyncClient):
     expected_status_codes = [200, 200, 429, 429, 429]
-    
+
     for i, expected_status_code in enumerate(expected_status_codes):
         try:
             response = await app_client_rate_limit.get("/collections")
             status_code = response.status_code
         except RateLimitExceeded:
             status_code = 429
-        
+
         logger.info(f"Request {i+1}: Status code {status_code}")
-        assert status_code == expected_status_code, f"Expected status code {expected_status_code}, but got {status_code}"
+        assert (
+            status_code == expected_status_code
+        ), f"Expected status code {expected_status_code}, but got {status_code}"

--- a/stac_fastapi/tests/rate_limit/test_rate_limit.py
+++ b/stac_fastapi/tests/rate_limit/test_rate_limit.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-async def test_rate_limit(app_client_rate_limit: AsyncClient):
+async def test_rate_limit(app_client_rate_limit: AsyncClient, ctx):
     expected_status_codes = [200, 200, 429, 429, 429]
 
     for i, expected_status_code in enumerate(expected_status_codes):
@@ -17,6 +17,20 @@ async def test_rate_limit(app_client_rate_limit: AsyncClient):
             status_code = response.status_code
         except RateLimitExceeded:
             status_code = 429
+
+        logger.info(f"Request {i+1}: Status code {status_code}")
+        assert (
+            status_code == expected_status_code
+        ), f"Expected status code {expected_status_code}, but got {status_code}"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_no_limit(app_client: AsyncClient, ctx):
+    expected_status_codes = [200, 200, 200, 200, 200]
+
+    for i, expected_status_code in enumerate(expected_status_codes):
+        response = await app_client.get("/collections")
+        status_code = response.status_code
 
         logger.info(f"Request {i+1}: Status code {status_code}")
         assert (


### PR DESCRIPTION
**Description:**
Implementation of address based global rate limiting **option**.

Rate limiting is an optional security feature that controls API request frequency on a remote address basis. It's enabled by setting the `STAC_FASTAPI_RATE_LIMIT` environment variable, e.g., `500/minute`. This limits each client to 500 requests per minute, helping prevent abuse and maintain API stability. Implementation examples are available in the [examples/rate_limit](examples/rate_limit) directory.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog