### PR TITLE
Clean up aggregation tests

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -168,7 +168,7 @@ def indices(collection_ids: Optional[List[str]]) -> str:
     Returns:
         A string of comma-separated index names. If `collection_ids` is None, returns the default indices.
     """
-    if collection_ids is None:
+    if collection_ids is None or collection_ids == []:
         return ITEM_INDICES
     else:
         return ",".join([index_by_collection_id(c) for c in collection_ids])
@@ -764,7 +764,6 @@ class DatabaseLogic:
             for k, v in self.aggregation_mapping.items()
             if k in aggregations
         }
-
         index_param = indices(collection_ids)
         search_task = asyncio.create_task(
             self.client.search(

--- a/stac_fastapi/tests/extensions/test_aggregation.py
+++ b/stac_fastapi/tests/extensions/test_aggregation.py
@@ -445,7 +445,7 @@ async def test_get_aggregate_datetime_min(app_client):
 
 
 @pytest.mark.asyncio
-async def test_post_aggregate_datetime_min(app_client):
+async def test_post_aggregate_datetime_min(app_client, ctx):
 
     params = {
         "aggregations": ["datetime_min"],

--- a/stac_fastapi/tests/extensions/test_aggregation.py
+++ b/stac_fastapi/tests/extensions/test_aggregation.py
@@ -461,7 +461,7 @@ async def test_post_aggregate_datetime_min(app_client):
 
 
 @pytest.mark.asyncio
-async def test_get_aggregate_datetime_frequency(app_client):
+async def test_get_aggregate_datetime_frequency(app_client, ctx):
 
     resp = await app_client.get("/aggregate?aggregations=datetime_frequency")
 
@@ -474,7 +474,7 @@ async def test_get_aggregate_datetime_frequency(app_client):
 
 
 @pytest.mark.asyncio
-async def test_post_aggregate_datetime_frequency(app_client):
+async def test_post_aggregate_datetime_frequency(app_client, ctx):
 
     params = {
         "aggregations": ["datetime_frequency"],
@@ -491,7 +491,7 @@ async def test_post_aggregate_datetime_frequency(app_client):
 
 
 @pytest.mark.asyncio
-async def test_get_aggregate_collection_frequency(app_client):
+async def test_get_aggregate_collection_frequency(app_client, ctx):
 
     resp = await app_client.get("/aggregate?aggregations=collection_frequency")
 
@@ -501,7 +501,7 @@ async def test_get_aggregate_collection_frequency(app_client):
 
 
 @pytest.mark.asyncio
-async def test_post_aggregate_collection_frequency(app_client):
+async def test_post_aggregate_collection_frequency(app_client, ctx):
 
     params = {
         "aggregations": ["collection_frequency"],

--- a/stac_fastapi/tests/extensions/test_aggregation.py
+++ b/stac_fastapi/tests/extensions/test_aggregation.py
@@ -173,7 +173,7 @@ async def test_aggregate_filter_extension_neq_post(app_client, ctx):
 
 
 @pytest.mark.asyncio
-async def test_aggregate_extension_gte_get(app_client):
+async def test_aggregate_extension_gte_get(app_client, ctx):
     # there's one item that can match, so one of these queries should match it and the other shouldn't
     resp = await app_client.get(
         '/aggregate?aggregations=total_count&filter-lang=cql2-json&filter={"op":"<=","args":[{"property": "properties.proj:epsg"},32756]}'
@@ -387,9 +387,7 @@ async def test_aggregate_datetime_non_interval(app_client):
 @pytest.mark.asyncio
 async def test_post_aggregate_total_count(app_client):
 
-    params = {
-        "aggregations": ["total_count"],
-    }
+    params = {"aggregations": ["total_count"]}
 
     resp = await app_client.post("/aggregate", json=params)
 

--- a/stac_fastapi/tests/extensions/test_filter.py
+++ b/stac_fastapi/tests/extensions/test_filter.py
@@ -20,21 +20,13 @@ async def test_filter_extension_landing_page_link(app_client, ctx):
 
 
 @pytest.mark.asyncio
-async def test_filter_extension_collection_link(app_client, load_test_data):
+async def test_filter_extension_collection_link(app_client, ctx):
     """Test creation and deletion of a collection"""
-    test_collection = load_test_data("test_collection.json")
-    test_collection["id"] = "test"
 
-    resp = await app_client.post("/collections", json=test_collection)
-    assert resp.status_code == 201
-
-    resp = await app_client.get(f"/collections/{test_collection['id']}")
+    resp = await app_client.get(f"/collections/{ctx.collection['id']}")
     resp_json = resp.json()
     keys = [link["rel"] for link in resp_json["links"]]
     assert "queryables" in keys
-
-    resp = await app_client.delete(f"/collections/{test_collection['id']}")
-    assert resp.status_code == 204
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Related Issue(s):**

- #290

**Description:**

General cleanup of the aggregation test in an effort to resolve #290. I am not able to reproduce the error locally, but I have also noticed the issue when testing is run on github. My best guess is that it is an issue with  async tests running in parallel. I made the following changes.

- removed all unnecessary uses of the `ctx` fixture.
- removed call for `load_test_data`

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog