### PR TITLE
Adding note on the use of the default `*` use in route authentication dependecies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Added note on the use of the default `*` use in route authentication dependecies. [#](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/)
+- Added note on the use of the default `*` use in route authentication dependecies. [#325](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/325)
 
 ## [v3.2.2] - 2024-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Added note on the use of the default `*` use in route authentication dependecies. [#](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/)
+
 ## [v3.2.2] - 2024-12-15
 
 ### Changed

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -9,6 +9,11 @@ Authentication is an optional feature that can be enabled through [Route Depende
 Route dependencies for endpoints can enable through the `STAC_FASTAPI_ROUTE_DEPENDENCIES` 
 environment variable as a path to a JSON file or a JSON string.
 
+***NOTE: default dependencies***
+`*` can be used match all paths. However, if used this must be the only Authentication dependency (multiple can be used through a 
+single merged dependency). Similarly, `*` can be used to match all methods with a route but must also be the only Authentication 
+dependency for that route.
+
 #### Route Dependency
 
 A Route Dependency must include `routes`, a list of at least one [Route](#routes), and `dependencies` a

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -10,7 +10,7 @@ Route dependencies for endpoints can enable through the `STAC_FASTAPI_ROUTE_DEPE
 environment variable as a path to a JSON file or a JSON string.
 
 ***NOTE: default dependencies***
-`*` can be used match all paths. However, if used this must be the only Authentication dependency (multiple can be used through a 
+`*` can be used to match all paths. However, if used this must be the only Authentication dependency (multiple can be used through a 
 single merged dependency). Similarly, `*` can be used to match all methods with a route but must also be the only Authentication 
 dependency for that route.
 


### PR DESCRIPTION
**Related Issue(s):**
- #310

**Description:**
Using multiple authentication dependencies on a single route can cause clashes if not done correctly (merging them). This is particularly relevant to the default `*` route. My [pull request](https://github.com/stac-utils/stac-fastapi/pull/766) on [stac-fastapi](https://github.com/stac-utils/stac-fastapi) to dynamically merge multiple dependencies was rejected and I don't think it's possible to replicate it here. So I've added a note to the dependency documentation to try to explain what to do in this case.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog