### PR TITLE
Support Py3.13

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: sfeos
 on:
   push:
     branches:
-      - main
+      - '*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: sfeos
 on:
   push:
     branches:
-      - '*'
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -65,7 +65,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         backend: [ "elasticsearch7", "elasticsearch8", "opensearch"]
 
     name: Python ${{ matrix.python-version }} testing with ${{ matrix.backend }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+## untitled - 2025-03-14
+
+- Support python 3.13 in STAC FastiAPI Core, Opensearch and ElasticSearch
+
 ## [v3.2.3] - 2025-02-11
 
 - Added note on the use of the default `*` use in route authentication dependecies. [#325](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/325)

--- a/stac_fastapi/core/setup.py
+++ b/stac_fastapi/core/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
     ],
     url="https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch",

--- a/stac_fastapi/core/setup.py
+++ b/stac_fastapi/core/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 install_requires = [
     "fastapi-slim",
     "attrs>=23.2.0",
-    "pydantic[dotenv]",
+    "pydantic",
     "stac_pydantic>=3",
     "stac-fastapi.types==3.0.0",
     "stac-fastapi.api==3.0.0",
@@ -17,7 +17,7 @@ install_requires = [
     "overrides",
     "geojson-pydantic",
     "pygeofilter==0.3.1",
-    "typing_extensions==4.8.0",
+    "typing_extensions>=4.8.0",
     "jsonschema",
     "slowapi==0.1.9",
 ]

--- a/stac_fastapi/core/setup.py
+++ b/stac_fastapi/core/setup.py
@@ -17,7 +17,6 @@ install_requires = [
     "overrides",
     "geojson-pydantic",
     "pygeofilter==0.3.1",
-    "typing_extensions>=4.8.0",
     "jsonschema",
     "slowapi==0.1.9",
 ]

--- a/stac_fastapi/elasticsearch/setup.py
+++ b/stac_fastapi/elasticsearch/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
     ],
     url="https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch",

--- a/stac_fastapi/opensearch/setup.py
+++ b/stac_fastapi/opensearch/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
     ],
     url="https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch",


### PR DESCRIPTION
**Related Issue(s):**
It's not an issue. We simply want to support python 3.13 in stac_fastapi.core via removing **type_extension**!
- #

**Description:**
It;s gonna close issue #335 as well


**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable
- [X] Changes are added to the changelog