### PR TITLE
feat: more configuration options for Elasticsearch/OpenSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Option to configure multiple Elasticsearch/OpenSearch hosts and enable `http_compress`. [#349](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/349)
+
 ### Changed
 
 ## [v3.2.4] - 2025-03-14

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/config.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/config.py
@@ -16,10 +16,13 @@ def _es_config() -> Dict[str, Any]:
     scheme = "https" if use_ssl else "http"
 
     # Configure the hosts parameter with the correct scheme
-    hosts = [f"{scheme}://{os.getenv('ES_HOST')}:{os.getenv('ES_PORT')}"]
+    hosts = [
+        f"{scheme}://{host.strip()}:{os.getenv('ES_PORT')}"
+        for host in os.getenv("ES_HOST").split(",")
+    ]
 
     # Initialize the configuration dictionary
-    config = {
+    config: Dict[str, Any] = {
         "hosts": hosts,
         "headers": {"accept": "application/vnd.elasticsearch+json; compatible-with=7"},
     }
@@ -33,6 +36,10 @@ def _es_config() -> Dict[str, Any]:
             config["headers"] = {"x-api-key": api_key}
 
         config["headers"] = headers
+
+    http_compress = os.getenv("ES_HTTP_COMPRESS", "true").lower() == "true"
+    if http_compress:
+        config["http_compress"] = True
 
     # Explicitly exclude SSL settings when not using SSL
     if not use_ssl:

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/config.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/config.py
@@ -15,13 +15,20 @@ def _es_config() -> Dict[str, Any]:
     scheme = "https" if use_ssl else "http"
 
     # Configure the hosts parameter with the correct scheme
-    hosts = [f"{scheme}://{os.getenv('ES_HOST')}:{os.getenv('ES_PORT')}"]
+    hosts = [
+        f"{scheme}://{host.strip()}:{os.getenv('ES_PORT')}"
+        for host in os.getenv("ES_HOST").split(",")
+    ]
 
     # Initialize the configuration dictionary
-    config = {
+    config: Dict[str, Any] = {
         "hosts": hosts,
         "headers": {"accept": "application/json", "Content-Type": "application/json"},
     }
+
+    http_compress = os.getenv("ES_HTTP_COMPRESS", "true").lower() == "true"
+    if http_compress:
+        config["http_compress"] = True
 
     # Explicitly exclude SSL settings when not using SSL
     if not use_ssl:


### PR DESCRIPTION
**Related Issue(s):**

- #348 

**Description:**
Allow to configure multiple Elasticsearch/OpenSearch hosts (comma-separated) and enable `http_compress` by default.


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog