### PR TITLE
Prevent property not allowed in terms query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Filter Extension - patch terms value to prevent 'property reference not allowed in terms query' 500 
+
 ### Added
 
 ### Changed

--- a/stac_fastapi/core/stac_fastapi/core/version.py
+++ b/stac_fastapi/core/stac_fastapi/core/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "4.2.0"
+__version__ = "4.2.1"

--- a/stac_fastapi/elasticsearch/setup.py
+++ b/stac_fastapi/elasticsearch/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "stac-fastapi-core==4.2.0",
+    "stac-fastapi-core==4.2.1",
     "elasticsearch[async]~=8.18.0",
     "uvicorn~=0.23.0",
     "starlette>=0.35.0,<0.36.0",

--- a/stac_fastapi/opensearch/setup.py
+++ b/stac_fastapi/opensearch/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "stac-fastapi-core==4.2.0",
+    "stac-fastapi-core==4.2.1",
     "opensearch-py~=2.8.0",
     "opensearch-py[async]~=2.8.0",
     "uvicorn~=0.23.0",

--- a/stac_fastapi/tests/extensions/test_filter.py
+++ b/stac_fastapi/tests/extensions/test_filter.py
@@ -160,6 +160,24 @@ async def test_search_filter_ext_and_get_cql2text_id(app_client, ctx):
 
 
 @pytest.mark.asyncio
+async def test_search_filter_ext_cql_property_terms_query(app_client, ctx):
+    """Tests for terms queries not supporting property reference."""
+    landsat_row = ctx.item["properties"]["landsat:row"]
+
+    cql2_text_property_queries = {
+        f'properties.landsat:row="{landsat_row}"': 1,
+        f'properties.landsat:row!="{landsat_row}"': 0,
+        f'properties.landsat:row IN ("{landsat_row}")': 1,
+    }
+
+    for filter, result in cql2_text_property_queries.items():
+        resp = await app_client.get(f"/search?filter-lang=cql2-text&filter={filter}")
+        content = resp.json()
+        assert resp.status_code == 200
+        assert len(content["features"]) == result
+
+
+@pytest.mark.asyncio
 async def test_search_filter_ext_and_get_cql2text_cloud_cover(app_client, ctx):
     collection = ctx.item["collection"]
     cloud_cover = ctx.item["properties"]["eo:cloud_cover"]


### PR DESCRIPTION
**Related Issue(s):**

[Terms query does not support property reference](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/issues/382)

- #

**Description:**

Fix terms queries property reference

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog