### PR TITLE
Update to v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v6.0.0] - 2025-06-22
+
 ### Added
 
 - Added support for PATCH update through  [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902) and [RFC 7396](https://datatracker.ietf.org/doc/html/rfc7396) [#291](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/291)
+
+### Changed
+
+- Updated stac-fastapi parent libraries to v6.0.0 [#291](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/291)
 
 ## [v5.0.0] - 2025-06-11
 
@@ -423,7 +429,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use genexp in execute_search and get_all_collections to return results.
 - Added db_to_stac serializer to item_collection method in core.py.
 
-[Unreleased]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v5.0.0...main
+[Unreleased]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v6.0.0...main
+[v6.0.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v5.0.0...v6.0.0
 [v5.0.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v4.2.0...v5.0.0
 [v4.2.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v4.1.0...v4.2.0
 [v4.1.0]: https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/compare/v4.0.0...v4.1.0

--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-elasticsearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Elasticsearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-elasticsearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8080
@@ -42,7 +42,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-opensearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Opensearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-opensearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8082

--- a/examples/auth/compose.basic_auth.yml
+++ b/examples/auth/compose.basic_auth.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-elasticsearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Elasticsearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-elasticsearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8080
@@ -43,7 +43,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-opensearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Opensearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-opensearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8082

--- a/examples/auth/compose.oauth2.yml
+++ b/examples/auth/compose.oauth2.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-elasticsearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Elasticsearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-elasticsearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8080
@@ -44,7 +44,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-opensearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Opensearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-opensearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8082

--- a/examples/auth/compose.route_dependencies.yml
+++ b/examples/auth/compose.route_dependencies.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-elasticsearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Elasticsearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-elasticsearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8080
@@ -43,7 +43,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-opensearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Opensearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-opensearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8082

--- a/examples/rate_limit/compose.rate_limit.yml
+++ b/examples/rate_limit/compose.rate_limit.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-elasticsearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Elasticsearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-elasticsearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8080
@@ -43,7 +43,7 @@ services:
     environment:
       - STAC_FASTAPI_TITLE=stac-fastapi-opensearch
       - STAC_FASTAPI_DESCRIPTION=A STAC FastAPI with an Opensearch backend
-      - STAC_FASTAPI_VERSION=5.0.0
+      - STAC_FASTAPI_VERSION=6.0.0
       - STAC_FASTAPI_LANDING_PAGE_ID=stac-fastapi-opensearch
       - APP_HOST=0.0.0.0
       - APP_PORT=8082

--- a/stac_fastapi/core/stac_fastapi/core/version.py
+++ b/stac_fastapi/core/stac_fastapi/core/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "5.0.0"
+__version__ = "6.0.0"

--- a/stac_fastapi/elasticsearch/setup.py
+++ b/stac_fastapi/elasticsearch/setup.py
@@ -6,8 +6,8 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "stac-fastapi-core==5.0.0",
-    "sfeos-helpers==5.0.0",
+    "stac-fastapi-core==6.0.0",
+    "sfeos-helpers==6.0.0",
     "elasticsearch[async]~=8.18.0",
     "uvicorn~=0.23.0",
     "starlette>=0.35.0,<0.36.0",

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -107,7 +107,7 @@ post_request_model = create_post_request_model(search_extensions)
 app_config = {
     "title": os.getenv("STAC_FASTAPI_TITLE", "stac-fastapi-elasticsearch"),
     "description": os.getenv("STAC_FASTAPI_DESCRIPTION", "stac-fastapi-elasticsearch"),
-    "api_version": os.getenv("STAC_FASTAPI_VERSION", "5.0.0"),
+    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.0.0"),
     "settings": settings,
     "extensions": extensions,
     "client": CoreClient(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "5.0.0"
+__version__ = "6.0.0"

--- a/stac_fastapi/opensearch/setup.py
+++ b/stac_fastapi/opensearch/setup.py
@@ -6,8 +6,8 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "stac-fastapi-core==5.0.0",
-    "sfeos-helpers==5.0.0",
+    "stac-fastapi-core==6.0.0",
+    "sfeos-helpers==6.0.0",
     "opensearch-py~=2.8.0",
     "opensearch-py[async]~=2.8.0",
     "uvicorn~=0.23.0",

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/app.py
@@ -108,7 +108,7 @@ post_request_model = create_post_request_model(search_extensions)
 app_config = {
     "title": os.getenv("STAC_FASTAPI_TITLE", "stac-fastapi-opensearch"),
     "description": os.getenv("STAC_FASTAPI_DESCRIPTION", "stac-fastapi-opensearch"),
-    "api_version": os.getenv("STAC_FASTAPI_VERSION", "5.0.0"),
+    "api_version": os.getenv("STAC_FASTAPI_VERSION", "6.0.0"),
     "settings": settings,
     "extensions": extensions,
     "client": CoreClient(

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "5.0.0"
+__version__ = "6.0.0"

--- a/stac_fastapi/sfeos_helpers/setup.py
+++ b/stac_fastapi/sfeos_helpers/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "stac-fastapi.core==5.0.0",
+    "stac-fastapi.core==6.0.0",
 ]
 
 setup(

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "5.0.0"
+__version__ = "6.0.0"


### PR DESCRIPTION
### Added

- Added support for PATCH update through  [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902) and [RFC 7396](https://datatracker.ietf.org/doc/html/rfc7396) [#291](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/291)

### Changed

- Updated stac-fastapi parent libraries to v6.0.0 [#291](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/291)