### PR TITLE
Added support for searching large amount of indices by moving the ind…

### DIFF
--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -65,6 +65,7 @@ from stac_fastapi.types.stac import Collection, Item
 logger = logging.getLogger(__name__)
 ES_MAX_URL_LENGTH = 4096
 
+
 async def create_index_templates() -> None:
     """
     Create index templates for the Collection and Item indices.
@@ -546,15 +547,15 @@ class DatabaseLogic(BaseDatabaseLogic):
 
         index_param = indices(collection_ids)
 
-        if len(index_param) > ES_MAX_URL_LENGTH-300:
+        if len(index_param) > ES_MAX_URL_LENGTH - 300:
             index_param = ITEM_INDICES
             index_filter = {"terms": {"collection": collection_ids}}
-            if not "bool" in search_body["query"]:
+            if "bool" not in search_body["query"]:
                 search_body["query"]["bool"] = {}
-            if not "filter" in search_body["query"]["bool"]:
+            if "filter" not in search_body["query"]["bool"]:
                 search_body["query"]["bool"]["filter"] = [index_filter]
             filters = search_body["query"]["bool"]["filter"]
-            if not index_filter in filters:
+            if index_filter not in filters:
                 filters.append(index_filter)
 
         max_result_window = MAX_LIMIT


### PR DESCRIPTION
**Description:**
When searching the catalog with the `/search`-endpoint, a `GET /<indices>/_search` request is done with all indices listed in the URL path. However when doing such a search on a large amount of indices, it is possible that the size of the endpoint exceed Elasticsearch’s maximum allowed HTTP line length (4096 bytes), resulting in the following error:

`{"code":"RequestError","description":"RequestError(400, 'too_long_http_line_exception', 'An HTTP line is larger than 4096 bytes.')"}`

The solution in this commit moves the indices from the endpoint to the body of the request once the amount of indices passes a certain threshold. The indices of the endpoint will be replaced by `ITEM_INDICES`. Since the query still filters on the correct indices, this change preserves the behavior while avoiding the URL length limitation.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog