### PR TITLE
Ensure Normalize func preserves milliseconds precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added `id` field as secondary sort to sort config to ensure unique pagination tokens. [#421](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/421)
 - Added default environment variable `STAC_ITEM_LIMIT` to SFEOS for result limiting of returned items and STAC collections [#419](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/419)
+- Updated the `format_datetime_range` function to support milliseconds. [#423](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/423)
 
 ### Changed
 

--- a/stac_fastapi/core/stac_fastapi/core/datetime_utils.py
+++ b/stac_fastapi/core/stac_fastapi/core/datetime_utils.py
@@ -17,17 +17,20 @@ def format_datetime_range(date_str: str) -> str:
     """
 
     def normalize(dt):
+        """Normalize datetime string and preserve millisecond precision."""
         dt = dt.strip()
         if not dt or dt == "..":
             return ".."
         dt_obj = rfc3339_str_to_datetime(dt)
         dt_utc = dt_obj.astimezone(timezone.utc)
-        return dt_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return dt_utc.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
     if not isinstance(date_str, str):
         return "../.."
+
     if "/" not in date_str:
         return f"{normalize(date_str)}/{normalize(date_str)}"
+
     try:
         start, end = date_str.split("/", 1)
     except Exception:


### PR DESCRIPTION
**Description:**
Fixes an issue in the OS STAC `/search` endpoint where datetime filters overwrite milliseconds. The queries return products outside the specified range because the filter was rounding datetimes to full seconds. This change ensures that milliseconds are preserved, so datetime filtering returns correct results.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog