### PR TITLE
better queryables

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/extensions/filter.py
+++ b/stac_fastapi/core/stac_fastapi/core/extensions/filter.py
@@ -41,24 +41,6 @@ DEFAULT_QUERYABLES: Dict[str, Dict[str, Any]] = {
         "description": "Creation Timestamp",
         "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json#/properties/updated",
     },
-    "cloud_cover": {
-        "description": "Cloud Cover",
-        "$ref": "https://stac-extensions.github.io/eo/v1.0.0/schema.json#/definitions/fields/properties/eo:cloud_cover",
-    },
-    "cloud_shadow_percentage": {
-        "title": "Cloud Shadow Percentage",
-        "description": "Cloud Shadow Percentage",
-        "type": "number",
-        "minimum": 0,
-        "maximum": 100,
-    },
-    "nodata_pixel_percentage": {
-        "title": "No Data Pixel Percentage",
-        "description": "No Data Pixel Percentage",
-        "type": "number",
-        "minimum": 0,
-        "maximum": 100,
-    },
 }
 """Queryables that are present in all collections."""
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/client.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/client.py
@@ -50,10 +50,12 @@ class EsAsyncBaseFiltersClient(AsyncBaseFiltersClient):
             return queryables
 
         properties: Dict[str, Any] = queryables["properties"].copy()
-        queryables.update({
-            "properties": properties,
-            "additionalProperties": False,
-        })
+        queryables.update(
+            {
+                "properties": properties,
+                "additionalProperties": False,
+            }
+        )
 
         mapping_data = await self.database.get_items_mapping(collection_id)
         mapping_properties = next(iter(mapping_data.values()))["mappings"]["properties"]

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/client.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/client.py
@@ -49,13 +49,11 @@ class EsAsyncBaseFiltersClient(AsyncBaseFiltersClient):
         if not collection_id:
             return queryables
 
-        properties: Dict[str, Any] = queryables["properties"]
-        queryables.update(
-            {
-                "properties": properties,
-                "additionalProperties": False,
-            }
-        )
+        properties: Dict[str, Any] = queryables["properties"].copy()
+        queryables.update({
+            "properties": properties,
+            "additionalProperties": False,
+        })
 
         mapping_data = await self.database.get_items_mapping(collection_id)
         mapping_properties = next(iter(mapping_data.values()))["mappings"]["properties"]


### PR DESCRIPTION
added missing copy(), updated DEFAULT_QUERYABLES so it contains only generic attributes
**Description:**
- Removed bug (missing copy()) causing  default queryables to be enriched by queryables from previous queryables endpoint query.
- Removed attributes cloud_cover, cloud_shadow_percentage, nodata_pixel_percentage since these are not generic for all collections ex. SAR data.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog