### PR TITLE
Add missing relations for pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Added missing relations in pagination for collections/{collection_id}/items, /search, /collections/{collection_id}/items, /collections. [[#432](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/432)]
+
 ## [v6.2.1] - 2025-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -376,7 +376,9 @@ The system uses a precise naming convention:
 - **Parameters**:
   - `limit`: Controls the number of collections returned per page
   - `token`: Used to retrieve subsequent pages of results
-- **Response Structure**: The `links` field in the response contains a `next` link with the token for the next page of results.
+- **Response Structure**: The `links` field in the response contains the following relations:
+  - `next` link with token for the next page of results.
+  - `previous` link with token for the previous page of results.
 - **Example Usage**:
   ```shell
   curl -X "GET" "http://localhost:8080/collections?limit=1&token=example_token"

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -238,7 +238,7 @@ class CoreClient(AsyncBaseCoreClient):
         limit = int(request.query_params.get("limit", os.getenv("STAC_ITEM_LIMIT", 10)))
         token = request.query_params.get("token")
 
-        collections, next_token = await self.database.get_all_collections(
+        collections, next_token, prev_token = await self.database.get_all_collections(
             token=token, limit=limit, request=request
         )
 
@@ -255,6 +255,10 @@ class CoreClient(AsyncBaseCoreClient):
         if next_token:
             next_link = PagingLinks(next=next_token, request=request).link_next()
             links.append(next_link)
+
+        if prev_token:
+            prev_token = PagingLinks(prev=prev_token, request=request).link_previous()
+            links.append(prev_token)
 
         return stac_types.Collections(collections=collections, links=links)
 
@@ -343,7 +347,7 @@ class CoreClient(AsyncBaseCoreClient):
             search = self.database.apply_bbox_filter(search=search, bbox=bbox)
 
         limit = int(request.query_params.get("limit", os.getenv("STAC_ITEM_LIMIT", 10)))
-        items, maybe_count, next_token = await self.database.execute_search(
+        items, maybe_count, next_token, prev_token = await self.database.execute_search(
             search=search,
             limit=limit,
             sort=None,
@@ -356,7 +360,12 @@ class CoreClient(AsyncBaseCoreClient):
             self.item_serializer.db_to_stac(item, base_url=base_url) for item in items
         ]
 
-        links = await PagingLinks(request=request, next=next_token).get_links()
+        links = await PagingLinks(
+            request=request,
+            next=next_token,
+            prev=prev_token,
+            collection_id=collection_id,
+        ).get_links()
 
         return stac_types.ItemCollection(
             type="FeatureCollection",
@@ -568,7 +577,7 @@ class CoreClient(AsyncBaseCoreClient):
         if search_request.limit:
             limit = search_request.limit
 
-        items, maybe_count, next_token = await self.database.execute_search(
+        items, maybe_count, next_token, prev_token = await self.database.execute_search(
             search=search,
             limit=limit,
             token=search_request.token,
@@ -593,7 +602,9 @@ class CoreClient(AsyncBaseCoreClient):
             )
             for item in items
         ]
-        links = await PagingLinks(request=request, next=next_token).get_links()
+        links = await PagingLinks(
+            request=request, next=next_token, prev=prev_token
+        ).get_links()
 
         return stac_types.ItemCollection(
             type="FeatureCollection",

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -171,7 +171,7 @@ class DatabaseLogic(BaseDatabaseLogic):
 
     async def get_all_collections(
         self, token: Optional[str], limit: int, request: Request
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> Tuple[List[Dict[str, Any]], Optional[str], Optional[str]]:
         """Retrieve a list of all collections from Elasticsearch, supporting pagination.
 
         Args:
@@ -189,12 +189,17 @@ class DatabaseLogic(BaseDatabaseLogic):
             index=COLLECTIONS_INDEX,
             body={
                 "sort": [{"id": {"order": "asc"}}],
-                "size": limit,
+                "size": limit + 1,
                 **({"search_after": search_after} if search_after is not None else {}),
             },
         )
 
         hits = response["hits"]["hits"]
+
+        has_more = len(hits) > limit
+        if has_more:
+            hits = hits[:limit]
+
         collections = [
             self.collection_serializer.db_to_stac(
                 collection=hit["_source"], request=request, extensions=self.extensions
@@ -206,7 +211,11 @@ class DatabaseLogic(BaseDatabaseLogic):
         if len(hits) == limit:
             next_token = hits[-1]["sort"][0]
 
-        return collections, next_token
+        prev_token = None
+        if token:
+            prev_token = token
+
+        return collections, next_token, prev_token
 
     async def get_one_item(self, collection_id: str, item_id: str) -> Dict:
         """Retrieve a single item from the database.
@@ -506,7 +515,7 @@ class DatabaseLogic(BaseDatabaseLogic):
         collection_ids: Optional[List[str]],
         datetime_search: Dict[str, Optional[str]],
         ignore_unavailable: bool = True,
-    ) -> Tuple[Iterable[Dict[str, Any]], Optional[int], Optional[str]]:
+    ) -> Tuple[Iterable[Dict[str, Any]], Optional[int], Optional[str], Optional[str]]:
         """Execute a search query with limit and other optional parameters.
 
         Args:
@@ -579,6 +588,10 @@ class DatabaseLogic(BaseDatabaseLogic):
             if hits and (sort_array := hits[limit - 1].get("sort")):
                 next_token = urlsafe_b64encode(orjson.dumps(sort_array)).decode()
 
+        prev_token = None
+        if token and hits:
+            if hits and (first_item_sort := hits[0].get("sort")):
+                prev_token = urlsafe_b64encode(orjson.dumps(first_item_sort)).decode()
         matched = (
             es_response["hits"]["total"]["value"]
             if es_response["hits"]["total"]["relation"] == "eq"
@@ -590,7 +603,7 @@ class DatabaseLogic(BaseDatabaseLogic):
             except Exception as e:
                 logger.error(f"Count task failed: {e}")
 
-        return items, matched, next_token
+        return items, matched, next_token, prev_token
 
     """ AGGREGATE LOGIC """
 

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -154,7 +154,7 @@ class DatabaseLogic(BaseDatabaseLogic):
 
     async def get_all_collections(
         self, token: Optional[str], limit: int, request: Request
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> Tuple[List[Dict[str, Any]], Optional[str], Optional[str]]:
         """
         Retrieve a list of all collections from Opensearch, supporting pagination.
 
@@ -167,12 +167,16 @@ class DatabaseLogic(BaseDatabaseLogic):
         """
         search_body = {
             "sort": [{"id": {"order": "asc"}}],
-            "size": limit,
+            "size": limit + 1,
         }
 
-        # Only add search_after to the query if token is not None and not empty
+        search_after = None
         if token:
-            search_after = [token]
+            try:
+                search_after = orjson.loads(urlsafe_b64decode(token))
+            except (ValueError, TypeError, orjson.JSONDecodeError):
+                search_after = [token]
+        if search_after:
             search_body["search_after"] = search_after
 
         response = await self.client.search(
@@ -181,6 +185,9 @@ class DatabaseLogic(BaseDatabaseLogic):
         )
 
         hits = response["hits"]["hits"]
+        has_more = len(hits) > limit
+        if has_more:
+            hits = hits[:limit]
         collections = [
             self.collection_serializer.db_to_stac(
                 collection=hit["_source"], request=request, extensions=self.extensions
@@ -189,13 +196,21 @@ class DatabaseLogic(BaseDatabaseLogic):
         ]
 
         next_token = None
-        if len(hits) == limit:
+        if has_more and hits:
             # Ensure we have a valid sort value for next_token
             next_token_values = hits[-1].get("sort")
             if next_token_values:
-                next_token = next_token_values[0]
+                next_token = urlsafe_b64encode(orjson.dumps(next_token_values)).decode()
 
-        return collections, next_token
+        prev_token = None
+        if token and hits:
+            first_token_values = hits[0].get("sort")
+            if first_token_values:
+                prev_token = urlsafe_b64encode(
+                    orjson.dumps(first_token_values)
+                ).decode()
+
+        return collections, next_token, prev_token
 
     async def get_one_item(self, collection_id: str, item_id: str) -> Dict:
         """Retrieve a single item from the database.
@@ -495,7 +510,7 @@ class DatabaseLogic(BaseDatabaseLogic):
         collection_ids: Optional[List[str]],
         datetime_search: Dict[str, Optional[str]],
         ignore_unavailable: bool = True,
-    ) -> Tuple[Iterable[Dict[str, Any]], Optional[int], Optional[str]]:
+    ) -> Tuple[Iterable[Dict[str, Any]], Optional[int], Optional[str], Optional[str]]:
         """Execute a search query with limit and other optional parameters.
 
         Args:
@@ -514,6 +529,7 @@ class DatabaseLogic(BaseDatabaseLogic):
                 - The total number of results (if the count could be computed), or None if the count could not be
                 computed.
                 - The token to be used to retrieve the next set of results, or None if there are no more results.
+                - The token to be used to retrieve the previous set of results, or None if this is the first page.
 
         Raises:
             NotFoundError: If the collections specified in `collection_ids` do not exist.
@@ -570,9 +586,14 @@ class DatabaseLogic(BaseDatabaseLogic):
         items = (hit["_source"] for hit in hits[:limit])
 
         next_token = None
+        prev_token = None
         if len(hits) > limit and limit < max_result_window:
             if hits and (sort_array := hits[limit - 1].get("sort")):
                 next_token = urlsafe_b64encode(orjson.dumps(sort_array)).decode()
+
+        if token and hits:
+            if hits and (first_item_sort := hits[0].get("sort")):
+                prev_token = urlsafe_b64encode(orjson.dumps(first_item_sort)).decode()
 
         matched = (
             es_response["hits"]["total"]["value"]
@@ -585,7 +606,7 @@ class DatabaseLogic(BaseDatabaseLogic):
             except Exception as e:
                 logger.error(f"Count task failed: {e}")
 
-        return items, matched, next_token
+        return items, matched, next_token, prev_token
 
     """ AGGREGATE LOGIC """
 


### PR DESCRIPTION
**Description:**

This PR fixes missing relations in OS STAC pagination to ensure consistent navigation across endpoints.
- Added `collection` and `parent` relations to the endpoint: collections/{collection_id}/items
- Added `previous` relation for the following endpoint: `/search`,  `/collections/{collection_id}/items`, `/collections`

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog