### PR TITLE
Correcting item collection fields numReturned & numMatched.

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -596,8 +596,8 @@ class CoreClient(AsyncBaseCoreClient):
             type="FeatureCollection",
             features=items,
             links=links,
-            numReturned=len(items),
-            numMatched=maybe_count,
+            numberReturned=len(items),
+            numberMatched=maybe_count,
         )
 
 

--- a/stac_fastapi/tests/api/test_api.py
+++ b/stac_fastapi/tests/api/test_api.py
@@ -130,8 +130,8 @@ async def test_app_context_results(app_client, txn_client, ctx, load_test_data):
 
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1
-    assert resp_json["numReturned"] == 1
-    if matched := resp_json.get("numMatched"):
+    assert resp_json["numberReturned"] == 1
+    if matched := resp_json.get("numberMatched"):
         assert matched == 1
 
 

--- a/stac_fastapi/tests/resources/test_item.py
+++ b/stac_fastapi/tests/resources/test_item.py
@@ -226,7 +226,7 @@ async def test_get_item_collection(app_client, ctx, txn_client):
     assert resp.status_code == 200
 
     item_collection = resp.json()
-    if matched := item_collection.get("numMatched"):
+    if matched := item_collection.get("numberMatched"):
         assert matched == item_count + 1
 
 
@@ -294,13 +294,13 @@ async def test_pagination(app_client, load_test_data):
     )
     assert resp.status_code == 200
     first_page = resp.json()
-    assert first_page["numReturned"] == 3
+    assert first_page["numberReturned"] == 3
 
     url_components = urlsplit(first_page["links"][0]["href"])
     resp = await app_client.get(f"{url_components.path}?{url_components.query}")
     assert resp.status_code == 200
     second_page = resp.json()
-    assert second_page["numReturned"] == 3
+    assert second_page["numberReturned"] == 3
 
 
 @pytest.mark.skip(reason="created and updated fields not be added with stac fastapi 3?")
@@ -615,14 +615,14 @@ async def test_item_search_get_query_extension(app_client, ctx):
         ),
     }
     resp = await app_client.get("/search", params=params)
-    assert resp.json()["numReturned"] == 0
+    assert resp.json()["numberReturned"] == 0
 
     params["query"] = json.dumps(
         {"proj:epsg": {"eq": test_item["properties"]["proj:epsg"]}}
     )
     resp = await app_client.get("/search", params=params)
     resp_json = resp.json()
-    assert resp_json["numReturned"] == 1
+    assert resp_json["numberReturned"] == 1
     assert (
         resp_json["features"][0]["properties"]["proj:epsg"]
         == test_item["properties"]["proj:epsg"]


### PR DESCRIPTION
**Description:**

The `numReturned` & `numMatched` for the itemCollection type should be `numberReturned` & `numberMatched`

https://github.com/radiantearth/stac-api-spec/blob/604ade6158de15b8ab068320ca41e25e2bf0e116/fragments/itemcollection/README.md#itemcollection-fields


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog