### PR TITLE
Support for disabling attributes nested in properties.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ dmypy.json
 # Virtualenv
 venv
 
+# VSCode folder
+.vscode
+
 /docs/src/api/*
 
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- support of disabled nested attributes in the properties dictionary. [#474](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/474)
 
 ## [v6.4.0] - 2025-09-24
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/client.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/filter/client.py
@@ -72,7 +72,9 @@ class EsAsyncBaseFiltersClient(AsyncBaseFiltersClient):
             field_properties = field_def.get("properties")
             if field_properties:
                 stack.extend(
-                    (f"{field_fqn}.{k}", v) for k, v in field_properties.items()
+                    (f"{field_fqn}.{k}", v)
+                    for k, v in field_properties.items()
+                    if v.get("enabled", True)
                 )
 
             # Skip non-indexed or disabled fields


### PR DESCRIPTION
**Description:**
during testing I realized that sfoes skips check on nested attributes in the mapping. In result everything from properties is passed to ...collection/.../queryables endpoint.
Example mapping:
```
{
    "mappings": {
      "dynamic_templates": [
        {
          "descriptions": {
            "match": "description",
            "match_mapping_type": "string",
            "mapping": {
              "type": "text"
            }
          }
        },
        {
          "titles": {
            "match": "title",
            "match_mapping_type": "string",
            "mapping": {
              "type": "text"
            }
          }
        },
        {
          "proj_epsg": {
            "match": "proj:epsg",
            "mapping": {
              "type": "integer"
            }
          }
        },
        {
          "proj_projjson": {
            "match": "proj:projjson",
            "mapping": {
              "enabled": false,
              "type": "object"
            }
          }
        },
        {
          "proj_centroid": {
            "match": "proj:centroid",
            "mapping": {
              "type": "geo_point"
            }
          }
        },
        {
          "proj_geometry": {
            "match": "proj:geometry",
            "mapping": {
              "enabled": false,
              "type": "object"
            }
          }
        },
        {
          "no_index_href": {
            "match": "href",
            "mapping": {
              "index": false,
              "type": "text"
            }
          }
        },
        {
          "strings": {
            "match_mapping_type": "string",
            "mapping": {
              "type": "keyword"
            }
          }
        },
        {
          "long_to_double": {
            "match_mapping_type": "long",
            "mapping": {
              "type": "double"
            }
          }
        },
        {
          "double_to_double": {
            "match_mapping_type": "double",
            "mapping": {
              "type": "double"
            }
          }
        }
      ],
      "numeric_detection": false,
      "properties": {
        "assets": {
          "type": "object",
          "enabled": false
        },
        "bbox": {
          "type": "double"
        },
        "collection": {
          "type": "keyword"
        },
        "geometry": {
          "type": "geo_shape"
        },
        "id": {
          "type": "keyword"
        },
        "links": {
          "type": "object",
          "enabled": false
        },
        "properties": {
          "properties": {
            "auth:schemes": {
              "type": "object",
              "enabled": false
            },
            "constellation": {
              "type": "keyword"
            },
            "created": {
              "type": "date"
            },
            "datetime": {
              "type": "date"
            },
            "end_datetime": {
              "type": "date"
            },
            "eo:cloud_cover": {
              "type": "double"
            },
            "eo:snow_cover": {
              "type": "double"
            },
            "eopf:datastrip_id": {
              "type": "keyword"
            },
            "eopf:datatake_id": {
              "type": "keyword"
            },
            "eopf:instrument_mode": {
              "type": "keyword"
            },
            "eopf:origin_datetime": {
              "type": "date"
            },
            "grid:code": {
              "type": "keyword"
            },
            "gsd": {
              "type": "double"
            },
            "instruments": {
              "type": "keyword"
            },
            "platform": {
              "type": "keyword"
            },
            "processing:datetime": {
              "type": "date"
            },
            "processing:facility": {
              "type": "keyword"
            },
            "processing:level": {
              "type": "keyword"
            },
            "processing:version": {
              "type": "keyword"
            },
            "product:timeliness": {
              "type": "keyword"
            },
            "product:timeliness_category": {
              "type": "keyword"
            },
            "product:type": {
              "type": "keyword"
            },
            "published": {
              "type": "date"
            },
            "sar:instrument_mode": {
              "type": "keyword"
            },
            "sat:absolute_orbit": {
              "type": "integer"
            },
            "sat:orbit_state": {
              "type": "keyword"
            },
            "sat:platform_international_designator": {
              "type": "keyword"
            },
            "sat:relative_orbit": {
              "type": "integer"
            },
            "start_datetime": {
              "type": "date"
            },
            "statistics": {
              "type": "object",
              "enabled": false
            },
            "storage:schemes": {
              "type": "object",
              "enabled": false
            },
            "updated": {
              "type": "date"
            },
            "view:azimuth": {
              "type": "double"
            },
            "view:incidence_angle": {
              "type": "double"
            },
            "view:sun_azimuth": {
              "type": "double"
            },
            "view:sun_elevation": {
              "type": "double"
            }
          }
        },
        "stac_extensions": {
          "type": "keyword"
        },
        "stac_version": {
          "type": "keyword"
        },
        "type": {
          "type": "keyword"
        }
      }
    }
  }
```

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog