### PR TITLE
Adding optional separate alias prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added test for conformance endpoint in catalogs extension. [#727](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/727)
+- Added option ITEMS_ALIAS_PREFIX environment variable to allow for multiple version of item indices. [#736](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/736)
 
 ### Changed
 
 ### Fixed
+
+- Update datetime fields default mapping to date from date_nanos. [#736](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/736)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,7 @@ ENABLE_DATETIME_INDEX_FILTERING=true
 | `ENABLE_DATETIME_INDEX_FILTERING` | Enables time-based index partitioning | `false` | `true` |
 | `DATETIME_INDEX_MAX_SIZE_GB` | Maximum size limit for datetime indexes (GB) - note: add +20% to target size due to ES/OS compression | `25` | `50` |
 | `STAC_ITEMS_INDEX_PREFIX` | Prefix for item indexes | `items_` | `stac_items_` |
+| `STAC_ITEMS_ALIAS_PREFIX` | Prefix for item aliases | `STAC_ITEMS_INDEX_PREFIX` | `stac-items-` |
 | `ENABLE_REDIS_QUEUE` | Enables Redis queue for async item processing | `false` | `true` |
 | `QUEUE_BATCH_SIZE` | Number of items to process in a single batch | `50` | `100` |
 | `QUEUE_FLUSH_INTERVAL` | Maximum seconds to wait before flushing queue (even if batch not full) | `30` | `60` |
@@ -1080,9 +1081,9 @@ The system uses a precise naming convention:
 
 **Aliases:**
 ```
-{ITEMS_INDEX_PREFIX}{collection-id}                                  # Main collection alias
-{ITEMS_INDEX_PREFIX}{collection-id}_{start-datetime}                 # Temporal alias
-{ITEMS_INDEX_PREFIX}{collection-id}_{start-datetime}_{end-datetime}  # Closed index alias
+{ITEMS_ALIAS_PREFIX}{collection-id}                                  # Main collection alias
+{ITEMS_ALIAS_PREFIX}{collection-id}_{start-datetime}                 # Temporal alias
+{ITEMS_ALIAS_PREFIX}{collection-id}_{start-datetime}_{end-datetime}  # Closed index alias
 ```
 
 **Example:**

--- a/scripts/reindex_elasticsearch.py
+++ b/scripts/reindex_elasticsearch.py
@@ -3,7 +3,7 @@ import time
 
 from stac_fastapi.elasticsearch.config import AsyncElasticsearchSettings
 from stac_fastapi.elasticsearch.database_logic import create_index_templates
-from stac_fastapi.sfeos_helpers.mappings import COLLECTIONS_INDEX, ITEMS_INDEX_PREFIX
+from stac_fastapi.sfeos_helpers.mappings import COLLECTIONS_INDEX, ITEMS_ALIAS_PREFIX
 
 
 async def reindex(client, index, new_index, aliases):
@@ -68,7 +68,7 @@ async def run():
     for collection in collections["hits"]["hits"]:
 
         item_indexes = await client.indices.get_alias(
-            name=f"{ITEMS_INDEX_PREFIX}{collection['_id']}*"
+            name=f"{ITEMS_ALIAS_PREFIX}{collection['_id']}*"
         )
 
         for item_index, aliases in item_indexes.items():

--- a/scripts/reindex_opensearch.py
+++ b/scripts/reindex_opensearch.py
@@ -3,7 +3,7 @@ import time
 
 from stac_fastapi.opensearch.config import AsyncOpensearchSettings
 from stac_fastapi.opensearch.database_logic import create_index_templates
-from stac_fastapi.sfeos_helpers.mappings import COLLECTIONS_INDEX, ITEMS_INDEX_PREFIX
+from stac_fastapi.sfeos_helpers.mappings import COLLECTIONS_INDEX, ITEMS_ALIAS_PREFIX
 
 
 async def reindex(client, index, new_index, aliases):
@@ -68,7 +68,7 @@ async def run():
     for collection in collections["hits"]["hits"]:
 
         item_indexes = await client.indices.get_alias(
-            name=f"{ITEMS_INDEX_PREFIX}{collection['_id']}*"
+            name=f"{ITEMS_ALIAS_PREFIX}{collection['_id']}*"
         )
 
         for item_index, aliases in item_indexes.items():

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -15,7 +15,6 @@ from elasticsearch.exceptions import BadRequestError
 from elasticsearch.exceptions import ConflictError as ESConflictError
 from elasticsearch.exceptions import NotFoundError as ESNotFoundError
 from fastapi import HTTPException
-from stac_fastapi.sfeos_helpers.database.index import index_by_collection_id
 from starlette.requests import Request
 
 import stac_fastapi.sfeos_helpers.filter as filter_module
@@ -65,6 +64,7 @@ from stac_fastapi.sfeos_helpers.database.catalogs import (
     decode_token_to_search_after,
     encode_search_after_to_token,
 )
+from stac_fastapi.sfeos_helpers.database.index import index_by_collection_id
 from stac_fastapi.sfeos_helpers.database.query import (
     ES_MAX_URL_LENGTH,
     add_collections_to_body,

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1,4 +1,5 @@
 """Database logic."""
+
 import asyncio
 import logging
 import os
@@ -14,6 +15,7 @@ from elasticsearch.exceptions import BadRequestError
 from elasticsearch.exceptions import ConflictError as ESConflictError
 from elasticsearch.exceptions import NotFoundError as ESNotFoundError
 from fastapi import HTTPException
+from stac_fastapi.sfeos_helpers.database.index import index_by_collection_id
 from starlette.requests import Request
 
 import stac_fastapi.sfeos_helpers.filter as filter_module
@@ -79,7 +81,6 @@ from stac_fastapi.sfeos_helpers.mappings import (
     COLLECTIONS_INDEX,
     DEFAULT_SORT,
     ITEM_INDICES,
-    ITEMS_INDEX_PREFIX,
     Geometry,
 )
 from stac_fastapi.sfeos_helpers.search_engine import (
@@ -435,7 +436,7 @@ class DatabaseLogic(BaseDatabaseLogic):
             dict: A dictionary containing the Queryables mappings.
         """
         mappings = await self.client.indices.get_mapping(
-            index=f"{ITEMS_INDEX_PREFIX}{collection_id}",
+            index=index_alias_by_collection_id(collection_id),
         )
         return await get_queryables_mapping_shared(
             collection_id=collection_id, mappings=mappings
@@ -1651,9 +1652,11 @@ class DatabaseLogic(BaseDatabaseLogic):
         collection_dict = (
             collection
             if isinstance(collection, dict)
-            else collection.model_dump()
-            if hasattr(collection, "model_dump")
-            else dict(collection)
+            else (
+                collection.model_dump()
+                if hasattr(collection, "model_dump")
+                else dict(collection)
+            )
         )
 
         # Handle collection ID change
@@ -1669,9 +1672,9 @@ class DatabaseLogic(BaseDatabaseLogic):
             await self.client.reindex(
                 body={
                     "dest": {
-                        "index": f"{ITEMS_INDEX_PREFIX}{collection_dict.get('id')}"
+                        "index": index_by_collection_id(collection_dict.get("id"))
                     },
-                    "source": {"index": f"{ITEMS_INDEX_PREFIX}{collection_id}"},
+                    "source": {"index": index_alias_by_collection_id(collection_id)},
                     "script": {
                         "lang": "painless",
                         "source": f"""ctx._id = ctx._id.replace('{collection_id}', '{collection_dict.get("id")}'); ctx._source.collection = '{collection_dict.get("id")}' ;""",  # noqa: E702
@@ -1679,6 +1682,29 @@ class DatabaseLogic(BaseDatabaseLogic):
                 },
                 wait_for_completion=True,
                 refresh=refresh,
+            )
+
+            await self.client.indices.update_aliases(
+                body={
+                    "actions": [
+                        {
+                            "remove": {
+                                "index": index_by_collection_id(collection_id),
+                                "alias": index_alias_by_collection_id(collection_id),
+                            }
+                        },
+                        {
+                            "add": {
+                                "index": index_by_collection_id(
+                                    collection_dict.get("id")
+                                ),
+                                "alias": index_alias_by_collection_id(
+                                    collection_dict.get("id")
+                                ),
+                            }
+                        },
+                    ]
+                }
             )
 
             # Delete the old collection

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -1,4 +1,5 @@
 """Database logic."""
+
 import asyncio
 import logging
 import os
@@ -14,6 +15,7 @@ from opensearchpy import Q, Search
 from opensearchpy.exceptions import ConflictError as OSConflictError
 from opensearchpy.exceptions import NotFoundError as OSNotFoundError
 from opensearchpy.exceptions import RequestError
+from stac_fastapi.sfeos_helpers.database.index import index_by_collection_id
 from starlette.requests import Request
 
 import stac_fastapi.sfeos_helpers.filter as filter_module
@@ -76,7 +78,6 @@ from stac_fastapi.sfeos_helpers.mappings import (
     DEFAULT_SORT,
     ES_COLLECTIONS_MAPPINGS,
     ITEM_INDICES,
-    ITEMS_INDEX_PREFIX,
     Geometry,
 )
 from stac_fastapi.sfeos_helpers.search_engine import (
@@ -434,7 +435,7 @@ class DatabaseLogic(BaseDatabaseLogic):
             dict: A dictionary containing the Queryables mappings.
         """
         mappings = await self.client.indices.get_mapping(
-            index=f"{ITEMS_INDEX_PREFIX}{collection_id}",
+            index=f"{ITEMS_ALIAS_PREFIX}{collection_id}",
         )
         return await get_queryables_mapping_shared(
             collection_id=collection_id, mappings=mappings
@@ -1631,9 +1632,11 @@ class DatabaseLogic(BaseDatabaseLogic):
         collection_dict = (
             collection
             if isinstance(collection, dict)
-            else collection.model_dump()
-            if hasattr(collection, "model_dump")
-            else dict(collection)
+            else (
+                collection.model_dump()
+                if hasattr(collection, "model_dump")
+                else dict(collection)
+            )
         )
 
         if collection_id != collection_dict.get("id"):
@@ -1646,9 +1649,9 @@ class DatabaseLogic(BaseDatabaseLogic):
             await self.client.reindex(
                 body={
                     "dest": {
-                        "index": f"{ITEMS_INDEX_PREFIX}{collection_dict.get('id')}"
+                        "index": index_by_collection_id(collection_dict.get("id"))
                     },
-                    "source": {"index": f"{ITEMS_INDEX_PREFIX}{collection_id}"},
+                    "source": {"index": index_alias_by_collection_id(collection_id)},
                     "script": {
                         "lang": "painless",
                         "source": f"""ctx._id = ctx._id.replace('{collection_id}', '{collection_dict.get("id")}'); ctx._source.collection = '{collection_dict.get("id")}' ;""",
@@ -1656,6 +1659,29 @@ class DatabaseLogic(BaseDatabaseLogic):
                 },
                 wait_for_completion=True,
                 refresh=refresh,
+            )
+
+            await self.client.indices.update_aliases(
+                body={
+                    "actions": [
+                        {
+                            "remove": {
+                                "index": index_by_collection_id(collection_id),
+                                "alias": index_alias_by_collection_id(collection_id),
+                            }
+                        },
+                        {
+                            "add": {
+                                "index": index_by_collection_id(
+                                    collection_dict.get("id")
+                                ),
+                                "alias": index_alias_by_collection_id(
+                                    collection_dict.get("id")
+                                ),
+                            }
+                        },
+                    ]
+                }
             )
 
             await self.delete_collection(collection_id=collection_id, **kwargs)

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -15,7 +15,6 @@ from opensearchpy import Q, Search
 from opensearchpy.exceptions import ConflictError as OSConflictError
 from opensearchpy.exceptions import NotFoundError as OSNotFoundError
 from opensearchpy.exceptions import RequestError
-from stac_fastapi.sfeos_helpers.database.index import index_by_collection_id
 from starlette.requests import Request
 
 import stac_fastapi.sfeos_helpers.filter as filter_module
@@ -61,6 +60,7 @@ from stac_fastapi.sfeos_helpers.database.catalogs import (
     decode_token_to_search_after,
     encode_search_after_to_token,
 )
+from stac_fastapi.sfeos_helpers.database.index import index_by_collection_id
 from stac_fastapi.sfeos_helpers.database.query import (
     ES_MAX_URL_LENGTH,
     add_collections_to_body,
@@ -78,6 +78,7 @@ from stac_fastapi.sfeos_helpers.mappings import (
     DEFAULT_SORT,
     ES_COLLECTIONS_MAPPINGS,
     ITEM_INDICES,
+    ITEMS_ALIAS_PREFIX,
     Geometry,
 )
 from stac_fastapi.sfeos_helpers.search_engine import (

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/index.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/index.py
@@ -16,8 +16,8 @@ from stac_fastapi.sfeos_helpers.mappings import (
     ES_ITEMS_MAPPINGS,
     ES_ITEMS_SETTINGS,
     ITEM_INDICES,
-    ITEMS_INDEX_PREFIX,
     ITEMS_ALIAS_PREFIX,
+    ITEMS_INDEX_PREFIX,
 )
 
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/index.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/index.py
@@ -48,7 +48,11 @@ def index_alias_by_collection_id(collection_id: str) -> str:
     Returns:
         str: The index alias derived from the collection id.
     """
-    cleaned = collection_id.translate(_ES_INDEX_NAME_UNSUPPORTED_CHARS_TABLE)
+    cleaned = (
+        "*"
+        if collection_id == "*"
+        else collection_id.translate(_ES_INDEX_NAME_UNSUPPORTED_CHARS_TABLE)
+    )
     return f"{ITEMS_ALIAS_PREFIX}{cleaned}"
 
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/index.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/index.py
@@ -17,6 +17,7 @@ from stac_fastapi.sfeos_helpers.mappings import (
     ES_ITEMS_SETTINGS,
     ITEM_INDICES,
     ITEMS_INDEX_PREFIX,
+    ITEMS_ALIAS_PREFIX,
 )
 
 
@@ -48,7 +49,7 @@ def index_alias_by_collection_id(collection_id: str) -> str:
         str: The index alias derived from the collection id.
     """
     cleaned = collection_id.translate(_ES_INDEX_NAME_UNSUPPORTED_CHARS_TABLE)
-    return f"{ITEMS_INDEX_PREFIX}{cleaned}"
+    return f"{ITEMS_ALIAS_PREFIX}{cleaned}"
 
 
 def indices(collection_ids: list[str] | None) -> str:

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
@@ -71,6 +71,7 @@ def apply_free_text_filter_shared(
             fields=fields,
             type="best_fields",
             fuzziness="AUTO",
+            lenient=True,
             operator="or",
         )
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
@@ -293,7 +293,7 @@ _ES_INDEX_NAME_UNSUPPORTED_CHARS_TABLE = str.maketrans(
     "", "", "".join(ES_INDEX_NAME_UNSUPPORTED_CHARS)
 )
 
-ITEM_INDICES = f"{ITEMS_INDEX_PREFIX}*,-*kibana*,-{COLLECTIONS_INDEX}*"
+ITEM_INDICES = f"{ITEMS_INDEX_PREFIX}*"
 
 DEFAULT_SORT = {
     "properties.datetime": {"order": "desc"},

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
@@ -272,6 +272,7 @@ class Geometry(Protocol):  # noqa
 
 COLLECTIONS_INDEX = os.getenv("STAC_COLLECTIONS_INDEX", "collections")
 ITEMS_INDEX_PREFIX = os.getenv("STAC_ITEMS_INDEX_PREFIX", "items_")
+ITEMS_ALIAS_PREFIX = os.getenv("STAC_ITEMS_INDEX_PREFIX", ITEMS_INDEX_PREFIX)
 
 ES_INDEX_NAME_UNSUPPORTED_CHARS = {
     "\\",
@@ -366,6 +367,7 @@ ES_MAPPINGS_DYNAMIC_TEMPLATES = get_dynamic_template(
     "STAC_FASTAPI_ES_CUSTOM_DYNAMIC_TEMPLATES", "STAC_FASTAPI_ES_DYNAMIC_TEMPLATES_FILE"
 )
 
+_DATE_MAPPING_TYPE = "date_nanos" if get_bool_env("USE_DATETIME_NANOS") else "date"
 # Base items mappings without dynamic configuration applied
 _BASE_ITEMS_MAPPINGS = {
     "numeric_detection": False,
@@ -380,9 +382,9 @@ _BASE_ITEMS_MAPPINGS = {
             "type": "object",
             "properties": {
                 # Common https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md
-                "datetime": {"type": "date_nanos"},
-                "start_datetime": {"type": "date_nanos"},
-                "end_datetime": {"type": "date_nanos"},
+                "datetime": {"type": _DATE_MAPPING_TYPE},
+                "start_datetime": {"type": _DATE_MAPPING_TYPE},
+                "end_datetime": {"type": _DATE_MAPPING_TYPE},
                 "created": {"type": "date"},
                 "updated": {"type": "date"},
                 # Satellite Extension https://github.com/stac-extensions/sat

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
@@ -293,7 +293,7 @@ _ES_INDEX_NAME_UNSUPPORTED_CHARS_TABLE = str.maketrans(
     "", "", "".join(ES_INDEX_NAME_UNSUPPORTED_CHARS)
 )
 
-ITEM_INDICES = f"{ITEMS_INDEX_PREFIX}*"
+ITEM_INDICES = f"{ITEMS_ALIAS_PREFIX}*"
 
 DEFAULT_SORT = {
     "properties.datetime": {"order": "desc"},

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/index_operations.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/index_operations.py
@@ -12,8 +12,8 @@ from stac_fastapi.sfeos_helpers.mappings import (
     _ES_INDEX_NAME_UNSUPPORTED_CHARS_TABLE,
     ES_ITEMS_MAPPINGS,
     ES_ITEMS_SETTINGS,
-    ITEMS_INDEX_PREFIX,
     ITEMS_ALIAS_PREFIX,
+    ITEMS_INDEX_PREFIX,
 )
 
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/index_operations.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/index_operations.py
@@ -13,6 +13,7 @@ from stac_fastapi.sfeos_helpers.mappings import (
     ES_ITEMS_MAPPINGS,
     ES_ITEMS_SETTINGS,
     ITEMS_INDEX_PREFIX,
+    ITEMS_ALIAS_PREFIX,
 )
 
 
@@ -185,7 +186,7 @@ class IndexOperations:
             str: Formatted alias name with prefix, type, collection ID, and date.
         """
         cleaned = collection_id.translate(_ES_INDEX_NAME_UNSUPPORTED_CHARS_TABLE)
-        return f"{ITEMS_INDEX_PREFIX}{name}_{cleaned.lower()}_{start_date}"
+        return f"{ITEMS_ALIAS_PREFIX}{name}_{cleaned.lower()}_{start_date}"
 
     @staticmethod
     def _create_index_body(aliases: Dict[str, Dict]) -> Dict[str, Any]:

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/selection/cache_manager.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/selection/cache_manager.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from stac_fastapi.sfeos_helpers.database import index_alias_by_collection_id
-from stac_fastapi.sfeos_helpers.mappings import ITEMS_INDEX_PREFIX
+from stac_fastapi.sfeos_helpers.mappings import ITEMS_ALIAS_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ class IndexCacheManager:
 
 
 def _serialize_cache(
-    data: dict[str, list[tuple[dict[str, str]]]]
+    data: dict[str, list[tuple[dict[str, str]]]],
 ) -> dict[str, list[list[dict[str, str]]]]:
     """Convert tuple values to lists for JSON serialization."""
     result = {}
@@ -93,7 +93,7 @@ def _serialize_cache(
 
 
 def _deserialize_cache(
-    data: dict[str, list[list[dict[str, str]]]]
+    data: dict[str, list[list[dict[str, str]]]],
 ) -> dict[str, list[tuple[dict[str, str]]]]:
     """Convert list values back to tuples after JSON deserialization."""
     result: dict[str, list[tuple[dict[str, str]]]] = {}
@@ -121,7 +121,7 @@ class IndexAliasLoader:
         Returns:
             dict[str, list[tuple[dict[str, str]]]]: Mapping of main collection aliases to their data.
         """
-        response = await self.client.indices.get_alias(index=f"{ITEMS_INDEX_PREFIX}*")
+        response = await self.client.indices.get_alias(index=f"{ITEMS_ALIAS_PREFIX}*")
         result: dict[str, list[tuple[dict[str, str]]]] = {}
 
         for index_name, index_info in response.items():
@@ -130,7 +130,7 @@ class IndexAliasLoader:
                 [
                     alias
                     for alias in aliases.keys()
-                    if alias.startswith(ITEMS_INDEX_PREFIX)
+                    if alias.startswith(ITEMS_ALIAS_PREFIX)
                 ]
             )
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/selection/selectors.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/search_engine/selection/selectors.py
@@ -1,4 +1,5 @@
 """Async index selectors with datetime-based filtering."""
+
 import logging
 from typing import Any, cast
 
@@ -8,7 +9,7 @@ from stac_fastapi.sfeos_helpers.database import (
     filter_indexes_by_datetime_range,
     return_date,
 )
-from stac_fastapi.sfeos_helpers.mappings import ITEM_INDICES, ITEMS_INDEX_PREFIX
+from stac_fastapi.sfeos_helpers.mappings import ITEM_INDICES, ITEMS_ALIAS_PREFIX
 
 from ...database import indices
 from .base import BaseIndexSelector
@@ -214,13 +215,13 @@ class DatetimeBasedIndexSelector(BaseIndexSelector):
     async def get_all_collection_ids(self) -> list[str] | None:
         """Return all known collection IDs derived from cached alias keys.
 
-        Strips the ITEMS_INDEX_PREFIX from each alias key to derive collection IDs.
+        Strips the ITEMS_ALIAS_PREFIX from each alias key to derive collection IDs.
 
         Returns:
             list[str] | None: List of collection IDs from the alias cache.
         """
         aliases = await self.alias_loader.get_aliases()
-        prefix_len = len(ITEMS_INDEX_PREFIX)
+        prefix_len = len(ITEMS_ALIAS_PREFIX)
         return [alias[prefix_len:] for alias in aliases.keys()]
 
 

--- a/stac_fastapi/tests/sfeos_helpers/test_mappings.py
+++ b/stac_fastapi/tests/sfeos_helpers/test_mappings.py
@@ -25,7 +25,7 @@ class TestMergeMappings:
         base = {
             "properties": {
                 "properties": {
-                    "datetime": {"type": "date_nanos"},
+                    "datetime": {"type": "date"},
                     "created": {"type": "date"},
                 }
             }
@@ -34,14 +34,14 @@ class TestMergeMappings:
         merge_mappings(base, custom)
 
         # Existing fields preserved
-        assert base["properties"]["properties"]["datetime"] == {"type": "date_nanos"}
+        assert base["properties"]["properties"]["datetime"] == {"type": "date"}
         assert base["properties"]["properties"]["created"] == {"type": "date"}
         # New field added
         assert base["properties"]["properties"]["custom_field"] == {"type": "keyword"}
 
     def test_custom_overwrites_on_key_collision(self):
         """Test that custom values overwrite base values when keys collide."""
-        base = {"level1": {"a": {"type": "date_nanos"}}}
+        base = {"level1": {"a": {"type": "date"}}}
         custom = {"level1": {"a": {"type": "date"}}}
         merge_mappings(base, custom)
         assert base["level1"]["a"] == {"type": "date"}
@@ -199,7 +199,7 @@ class TestApplyCustomMappings:
             "numeric_detection": False,
             "properties": {
                 "id": {"type": "keyword"},
-                "properties": {"properties": {"datetime": {"type": "date_nanos"}}},
+                "properties": {"properties": {"datetime": {"type": "date"}}},
             },
         }
         custom_json = json.dumps(
@@ -217,7 +217,7 @@ class TestApplyCustomMappings:
         # Existing fields preserved
         assert mappings["properties"]["id"] == {"type": "keyword"}
         assert mappings["properties"]["properties"]["properties"]["datetime"] == {
-            "type": "date_nanos"
+            "type": "date"
         }
         # New fields added
         assert mappings["properties"]["properties"]["properties"][
@@ -282,7 +282,7 @@ class TestGetItemsMappings:
         assert mappings["properties"]["id"] == {"type": "keyword"}
         assert mappings["properties"]["geometry"] == {"type": "geo_shape"}
         assert mappings["properties"]["properties"]["properties"]["datetime"] == {
-            "type": "date_nanos"
+            "type": "date"
         }
 
     def test_custom_can_override_defaults(self):
@@ -362,7 +362,7 @@ class TestSTACExtensionUseCases:
         ].items():
             assert props[field_name] == field_config
         # Default fields still present
-        assert props["datetime"] == {"type": "date_nanos"}
+        assert props["datetime"] == {"type": "date"}
 
     def test_performance_optimization_with_disabled_dynamic_mapping(self):
         """Test disabling dynamic mapping with selective field indexing."""


### PR DESCRIPTION
**Description:**
Adds environment variable `STAC_ITEMS_INDEX_PREFIX` to set `ITEMS_ALIAS_PREFIX` to seperate alias and index names. This allows multiple version of item indices to exist on the cluster with only those that have been aliased will be queried.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog