### PR TITLE
fix: helm chart sets redis env vars when values are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed Redis pagination for POST requests. Properly handled pagination tokens for the previous, self, and next links in the response. [#808](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/808)
+- Fixed Helm chart redis values. Settings are now propagated to the sfeos pod. [#829](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/829)
 
 ### Removed
 

--- a/helm-chart/stac-fastapi/templates/_helpers.tpl
+++ b/helm-chart/stac-fastapi/templates/_helpers.tpl
@@ -208,6 +208,19 @@ Resolve the Redis port based on the active configuration
 {{- end }}
 
 {{/*
+Resolve the Redis database based on the active configuration
+*/}}
+{{- define "stac-fastapi.redisDatabase" -}}
+{{- if and (.Values.redis.enabled) (not (and .Values.redis.external .Values.redis.external.enabled)) -}}
+  {{- .Values.redis.database -}}
+{{- else if and .Values.redis.external .Values.redis.external.enabled -}}
+  {{- .Values.redis.external.database | default 0 -}}
+{{- else }}
+  {{- 0 -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the image repository with tag
 */}}
 {{- define "stac-fastapi.image" -}}
@@ -235,6 +248,7 @@ Create environment variables for the application
 {{- $dbAuth := deepCopy (default (dict) .Values.app.databaseAuth) -}}
 {{- $opensearchSecurity := default (dict) .Values.opensearchSecurity -}}
 {{- $redisConfig := default (dict) .Values.redis -}}
+{{- $redisAuth := default (dict) (get $redisConfig "auth") -}}
 {{- $redisExternal := default (dict) (get $redisConfig "external") -}}
 {{- $redisEnabled := or ($redisConfig.enabled) (and $redisExternal ($redisExternal.enabled)) -}}
 {{- if and (eq .Values.backend "opensearch") (get $opensearchSecurity "generateAdminPassword") }}
@@ -310,6 +324,29 @@ Create environment variables for the application
 {{- end }}
 {{- range $i, $val := $extraEnv }}
 - {{ $val | toYaml | nindent 2 }}
+{{- end }}
+{{- if $redisEnabled }}
+- name: REDIS_ENABLE
+  value: "true"
+- name: REDIS_HOST
+  value: {{ include "stac-fastapi.redisHost" . | quote }}
+- name: REDIS_PORT
+  value: {{ include "stac-fastapi.redisPort" . | quote }}
+- name: REDIS_DB
+  value: {{ include "stac-fastapi.redisDatabase" . | quote }}
+{{- if $redisAuth.enabled }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $redisAuth.existingSecret | required "When redis auth is enabled you must provide a credential secret at redis.auth.existingSecret." }}
+      key: {{ $redisAuth.existingSecretPasswordKey | required "When redis auth is enabled you must provide the target key in the credential secret at redis.auth.existingSecretPasswordKey." }}
+{{- else if and $redisExternal.passwordSecret $redisExternal.passwordKey }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $redisExternal.passwordSecret }}
+      key: {{ $redisExternal.passwordKey }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/helm-chart/stac-fastapi/templates/_helpers.tpl
+++ b/helm-chart/stac-fastapi/templates/_helpers.tpl
@@ -326,12 +326,16 @@ Create environment variables for the application
   value: {{ include "stac-fastapi.redisPort" . | quote }}
 {{- end }}
 {{- if not (hasKey $env "REDIS_DB") }}
-{{- if and (.Values.redis.enabled) (not (and .Values.redis.external .Values.redis.external.enabled)) -}}
+{{- if and (.Values.redis.enabled) (not (and .Values.redis.external .Values.redis.external.enabled)) }}
+{{- if ne .Values.redis.database nil }}
 - name: REDIS_DB
-  value: {{- .Values.redis.database -}}
-{{- else if and .Values.redis.external .Values.redis.external.enabled -}}
+  value: {{ .Values.redis.database | quote }}
+{{- end }}
+{{- else if and .Values.redis.external .Values.redis.external.enabled }}
+{{- if ne .Values.redis.external.database nil }}
 - name: REDIS_DB
-  value: {{- .Values.redis.external.database | default 0 -}}
+  value: {{ (.Values.redis.external.database | default 0) | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if not (or (hasKey $env "REDIS_PASSWORD") (hasKey $envFromSecret "REDIS_PASSWORD")) }}

--- a/helm-chart/stac-fastapi/templates/_helpers.tpl
+++ b/helm-chart/stac-fastapi/templates/_helpers.tpl
@@ -208,19 +208,6 @@ Resolve the Redis port based on the active configuration
 {{- end }}
 
 {{/*
-Resolve the Redis database based on the active configuration
-*/}}
-{{- define "stac-fastapi.redisDatabase" -}}
-{{- if and (.Values.redis.enabled) (not (and .Values.redis.external .Values.redis.external.enabled)) -}}
-  {{- .Values.redis.database -}}
-{{- else if and .Values.redis.external .Values.redis.external.enabled -}}
-  {{- .Values.redis.external.database | default 0 -}}
-{{- else }}
-  {{- 0 -}}
-{{- end }}
-{{- end }}
-
-{{/*
 Create the image repository with tag
 */}}
 {{- define "stac-fastapi.image" -}}
@@ -339,8 +326,13 @@ Create environment variables for the application
   value: {{ include "stac-fastapi.redisPort" . | quote }}
 {{- end }}
 {{- if not (hasKey $env "REDIS_DB") }}
+{{- if and (.Values.redis.enabled) (not (and .Values.redis.external .Values.redis.external.enabled)) -}}
 - name: REDIS_DB
-  value: {{ include "stac-fastapi.redisDatabase" . | quote }}
+  value: {{- .Values.redis.database -}}
+{{- else if and .Values.redis.external .Values.redis.external.enabled -}}
+- name: REDIS_DB
+  value: {{- .Values.redis.external.database | default 0 -}}
+{{- end }}
 {{- end }}
 {{- if not (or (hasKey $env "REDIS_PASSWORD") (hasKey $envFromSecret "REDIS_PASSWORD")) }}
 {{- if $redisAuth.enabled }}

--- a/helm-chart/stac-fastapi/templates/_helpers.tpl
+++ b/helm-chart/stac-fastapi/templates/_helpers.tpl
@@ -347,8 +347,8 @@ Create environment variables for the application
 - name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ $redisAuth.existingSecret | required "When redis auth is enabled you must provide a credential secret at redis.auth.existingSecret." }}
-      key: {{ $redisAuth.existingSecretPasswordKey | required "When redis auth is enabled you must provide the target key in the credential secret at redis.auth.existingSecretPasswordKey." }}
+      name: {{ $redisAuth.existingSecret }}
+      key: {{ $redisAuth.existingSecretPasswordKey }}
 {{- else if and $redisExternal.passwordSecret $redisExternal.passwordKey }}
 - name: REDIS_PASSWORD
   valueFrom:

--- a/helm-chart/stac-fastapi/templates/_helpers.tpl
+++ b/helm-chart/stac-fastapi/templates/_helpers.tpl
@@ -326,14 +326,23 @@ Create environment variables for the application
 - {{ $val | toYaml | nindent 2 }}
 {{- end }}
 {{- if $redisEnabled }}
+{{- if not (hasKey $env "REDIS_ENABLE") }}
 - name: REDIS_ENABLE
   value: "true"
+{{- end }}
+{{- if not (hasKey $env "REDIS_HOST") }}
 - name: REDIS_HOST
   value: {{ include "stac-fastapi.redisHost" . | quote }}
+{{- end }}
+{{- if not (hasKey $env "REDIS_PORT") }}
 - name: REDIS_PORT
   value: {{ include "stac-fastapi.redisPort" . | quote }}
+{{- end }}
+{{- if not (hasKey $env "REDIS_DB") }}
 - name: REDIS_DB
   value: {{ include "stac-fastapi.redisDatabase" . | quote }}
+{{- end }}
+{{- if not (or (hasKey $env "REDIS_PASSWORD") (hasKey $envFromSecret "REDIS_PASSWORD")) }}
 {{- if $redisAuth.enabled }}
 - name: REDIS_PASSWORD
   valueFrom:

--- a/helm-chart/stac-fastapi/templates/_helpers.tpl
+++ b/helm-chart/stac-fastapi/templates/_helpers.tpl
@@ -350,6 +350,7 @@ Create environment variables for the application
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{/*
 Determine if Elasticsearch should be enabled based on backend selection

--- a/helm-chart/stac-fastapi/values.yaml
+++ b/helm-chart/stac-fastapi/values.yaml
@@ -396,6 +396,7 @@ redis:
     enabled: false
     host: ""
     port: 6379
+    database: 0
     # Optional secret that stores the Redis password for the external instance
     passwordSecret: ""
     passwordKey: "redis-password"

--- a/helm-chart/stac-fastapi/values.yaml
+++ b/helm-chart/stac-fastapi/values.yaml
@@ -380,7 +380,7 @@ redis:
   # Optional override for the generated Redis fullname
   fullnameOverride: ""
   # Default Redis database index used by the application
-  database: 0
+  # database:
   architecture: standalone
   master:
     service:
@@ -396,7 +396,7 @@ redis:
     enabled: false
     host: ""
     port: 6379
-    database: 0
+    # database:
     # Optional secret that stores the Redis password for the external instance
     passwordSecret: ""
     passwordKey: "redis-password"


### PR DESCRIPTION
**Related Issue(s):**

- #828 

**Description:**

When either `redis.enabled: true` or `redis.external.enabled: true` are set this PR causes the helm chart to set relevant redis env vars on the sfeos deployment. This also sets the not yet supported `REDIS_PASSWORD` env var. I know this does nothing but I wanted the implement all existing helm values related to redis and I hope to implement support for password protected redis as well as redis sentinel in different PRs.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
Some of these fail but it doesn't really seem related to my changes. Maybe something wrong with my local setup?
- [x] Documentation has been updated to reflect changes, if applicable (not applicable here)
- [x] Changes are added to the changelog