### PR TITLE
feat: merge queryables enums

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/queryables.py
+++ b/stac_fastapi/core/stac_fastapi/core/queryables.py
@@ -138,6 +138,9 @@ def merge_queryables(collection_queryables: list[dict]) -> dict:
                         f"Conflict detected for queryable '{prop_name}'. "
                         f"Keeping existing definition: {existing_def}. Ignoring: {prop_def}."
                     )
+                # if both properties of the same types and are enumerations, merge the enum values
+                if existing_def.get("type") == prop_def.get("type") and (values := existing_def.get("enum")):
+                    existing_def["enum"] = list({*values, *prop_def.get("enum", [])})
             else:
                 merged_properties[prop_name] = prop_def
 

--- a/stac_fastapi/tests/extensions/test_queryables_root.py
+++ b/stac_fastapi/tests/extensions/test_queryables_root.py
@@ -85,6 +85,7 @@ async def test_root_queryables_union(
     item_2["id"] = f"item-2-{uuid.uuid4()}"
     item_2["collection"] = collection_2["id"]
     item_2["properties"]["field2"] = 42
+    item_2["properties"]["platform"] = "landsat-9"
     r = await app_client.post(f"/collections/{collection_2['id']}/items", json=item_2)
     r.raise_for_status()
 
@@ -101,6 +102,10 @@ async def test_root_queryables_union(
     assert "field2" in properties
     assert properties["field1"]["type"] == "string"
     assert properties["field2"]["type"] == "number"
+
+    # The platform field should be present and have the correct enum values from both items
+    assert properties["platform"]["type"] == "string"
+    assert set(properties["platform"]["enum"]) == {"landsat-8", "landsat-9"}
 
     # Baseline queryable id should also be there
     assert "id" in properties


### PR DESCRIPTION
**Related Issue(s):**

When using [ROOT_QUERYABLES_UNION](https://stac-utils.github.io/stac-fastapi-elasticsearch-opensearch/#root-queryables-configuration) users might expect to have enumerations merged. 

**Description:**


**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] Changes are added to the changelog