### PR TITLE
feat: allow setting username/password for redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed Redis pagination for POST requests. Properly handled pagination tokens for the previous, self, and next links in the response. [#808](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/808)
+- Fixed Helm chart redis values. Settings are now propagated to the sfeos pod. [#829](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/829)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed Redis pagination for POST requests. Properly handled pagination tokens for the previous, self, and next links in the response. [#808](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/808)
-- Fixed Helm chart redis values. Settings are now propagated to the sfeos pod. [#829](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/829)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1369,6 +1369,8 @@ These Redis configuration variables enable proper navigation functionality in ST
 | `REDIS_PORT` | Redis server port for Redis configuration. | `6379`                   | Conditional (required for standalone Redis)                                                 |
 | **Both** |                                                                                              |                          |                                                                                             |
 | `REDIS_DB` | Redis database number to use for caching.                                                    | `0` (Sentinel) / `15` (Standalone) | Optional                                                                                    |
+| `REDIS_USERNAME` | If your redis instance uses ACLs for authentication you may provide a username here. | `""` | Optional |
+| `REDIS_PASSWORD` | Password for authentication enabled redis instances. | `""` | Optional |
 | `REDIS_MAX_CONNECTIONS` | Maximum number of connections in the Redis connection pool.                                  | `10`                     | Optional                                                                                    |
 | `REDIS_RETRY_TIMEOUT` | Enable retry on timeout for Redis operations.                                                | `true`                   | Optional                                                                                    |
 | `REDIS_DECODE_RESPONSES`      | Automatically decode Redis responses to strings.                                             | `true`                   | Optional                                                                                    |

--- a/stac_fastapi/core/stac_fastapi/core/redis_utils.py
+++ b/stac_fastapi/core/stac_fastapi/core/redis_utils.py
@@ -23,6 +23,8 @@ class RedisCommonSettings(BaseSettings):
     """Common configuration for Redis Sentinel and Redis Standalone."""
 
     REDIS_DB: int = 15
+    REDIS_USERNAME: str | None = None
+    REDIS_PASSWORD: str | None = None
     REDIS_MAX_CONNECTIONS: int | None = None
     REDIS_RETRY_TIMEOUT: bool = True
     REDIS_DECODE_RESPONSES: bool = True
@@ -163,6 +165,8 @@ async def _connect_redis_internal() -> aioredis.Redis | None:
         redis = sentinel.master_for(
             service_name=settings.REDIS_SENTINEL_MASTER_NAME,
             db=settings.REDIS_DB,
+            username=settings.REDIS_USERNAME,
+            password=settings.REDIS_PASSWORD,
             decode_responses=settings.REDIS_DECODE_RESPONSES,
             retry_on_timeout=settings.REDIS_RETRY_TIMEOUT,
             client_name=settings.REDIS_CLIENT_NAME,
@@ -176,6 +180,8 @@ async def _connect_redis_internal() -> aioredis.Redis | None:
             host=settings.REDIS_HOST,
             port=settings.REDIS_PORT,
             db=settings.REDIS_DB,
+            username=settings.REDIS_USERNAME,
+            password=settings.REDIS_PASSWORD,
             max_connections=settings.REDIS_MAX_CONNECTIONS,
             decode_responses=settings.REDIS_DECODE_RESPONSES,
             retry_on_timeout=settings.REDIS_RETRY_TIMEOUT,
@@ -374,6 +380,8 @@ class AsyncRedisQueueManager:
             return sentinel.master_for(
                 _sentinel_settings.REDIS_SENTINEL_MASTER_NAME,
                 db=_sentinel_settings.REDIS_DB,
+                username=_sentinel_settings.REDIS_USERNAME,
+                password=_sentinel_settings.REDIS_PASSWORD,
                 decode_responses=True,
             )
         else:
@@ -385,6 +393,8 @@ class AsyncRedisQueueManager:
                 host=standalone_settings.REDIS_HOST,
                 port=standalone_settings.REDIS_PORT,
                 db=standalone_settings.REDIS_DB,
+                username=standalone_settings.REDIS_USERNAME,
+                password=standalone_settings.REDIS_PASSWORD,
                 decode_responses=True,
             )
 

--- a/stac_fastapi/tests/redis/test_redis_utils.py
+++ b/stac_fastapi/tests/redis/test_redis_utils.py
@@ -2,7 +2,12 @@ import pytest
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 import stac_fastapi.core.redis_utils as redis_utils
-from stac_fastapi.core.redis_utils import connect_redis, get_prev_link, save_prev_link
+from stac_fastapi.core.redis_utils import (
+    AsyncRedisQueueManager,
+    connect_redis,
+    get_prev_link,
+    save_prev_link,
+)
 
 
 @pytest.mark.asyncio
@@ -50,6 +55,120 @@ async def test_redis_utils_functions():
         redis, "http://mywebsite.com/search", "non_existent_token"
     )
     assert non_existent is None
+
+
+@pytest.mark.asyncio
+async def test_connect_redis_standalone_passes_username_and_password(monkeypatch):
+    monkeypatch.setattr(
+        redis_utils.sentinel_settings, "REDIS_SENTINEL_HOSTS", "", raising=False
+    )
+    monkeypatch.setattr(redis_utils.settings, "REDIS_HOST", "redis-host", raising=False)
+    monkeypatch.setattr(
+        redis_utils.settings, "REDIS_USERNAME", "testuser", raising=False
+    )
+    monkeypatch.setattr(
+        redis_utils.settings, "REDIS_PASSWORD", "testpass", raising=False
+    )
+
+    captured_kwargs = {}
+
+    class FakeConnectionPool:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(redis_utils.aioredis, "ConnectionPool", FakeConnectionPool)
+    monkeypatch.setattr(redis_utils.aioredis, "Redis", lambda **kwargs: object())
+
+    await redis_utils._connect_redis_internal()
+
+    assert captured_kwargs["username"] == "testuser"
+    assert captured_kwargs["password"] == "testpass"
+
+
+@pytest.mark.asyncio
+async def test_connect_redis_sentinel_passes_username_and_password(monkeypatch):
+    # `settings` and `sentinel_settings` are the same object whenever sentinel mode
+    # is active in a real process (both derived from REDIS_SENTINEL_HOSTS at import
+    # time) - keep that invariant here so `settings.get_sentinel_nodes()` resolves.
+    monkeypatch.setattr(redis_utils, "settings", redis_utils.sentinel_settings)
+    monkeypatch.setattr(
+        redis_utils.sentinel_settings,
+        "REDIS_SENTINEL_HOSTS",
+        "sentinel-host",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        redis_utils.sentinel_settings, "REDIS_USERNAME", "testuser", raising=False
+    )
+    monkeypatch.setattr(
+        redis_utils.sentinel_settings, "REDIS_PASSWORD", "testpass", raising=False
+    )
+
+    captured_kwargs = {}
+
+    class FakeSentinel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def master_for(self, *args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return object()
+
+    monkeypatch.setattr(redis_utils, "Sentinel", FakeSentinel)
+
+    await redis_utils._connect_redis_internal()
+
+    assert captured_kwargs["username"] == "testuser"
+    assert captured_kwargs["password"] == "testpass"
+
+
+@pytest.mark.asyncio
+async def test_queue_manager_connect_standalone_passes_username_and_password(
+    monkeypatch,
+):
+    monkeypatch.delenv("REDIS_SENTINEL_HOSTS", raising=False)
+    monkeypatch.setenv("REDIS_HOST", "redis-host")
+    monkeypatch.setenv("REDIS_USERNAME", "testuser")
+    monkeypatch.setenv("REDIS_PASSWORD", "testpass")
+
+    captured_kwargs = {}
+
+    def fake_redis(**kwargs):
+        captured_kwargs.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(redis_utils.aioredis, "Redis", fake_redis)
+
+    await AsyncRedisQueueManager._connect()
+
+    assert captured_kwargs["username"] == "testuser"
+    assert captured_kwargs["password"] == "testpass"
+
+
+@pytest.mark.asyncio
+async def test_queue_manager_connect_sentinel_passes_username_and_password(
+    monkeypatch,
+):
+    monkeypatch.setenv("REDIS_SENTINEL_HOSTS", "sentinel-host")
+    monkeypatch.setenv("REDIS_USERNAME", "testuser")
+    monkeypatch.setenv("REDIS_PASSWORD", "testpass")
+
+    captured_kwargs = {}
+
+    class FakeSentinel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def master_for(self, *args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return object()
+
+    monkeypatch.setattr(redis_utils, "Sentinel", FakeSentinel)
+
+    await AsyncRedisQueueManager._connect()
+
+    assert captured_kwargs["username"] == "testuser"
+    assert captured_kwargs["password"] == "testpass"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Related Issue(s):**

- #835 

**Description:**
This allows the user to set the env variables `REDIS_USERNAME` and `REDIS_PASSWORD`. When redis is enabled and these are set they get used to connect to the host. Since redis only added support for ACLs with redis 6.0 and prior versions had an implicit single user model setting a password without setting a user should explicitly be allowed (newer versions of redis also support this for backwards compatibility).

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
The tests I added and all redis related existing tests do pass. Some others don't. Again maybe related to my local setup?
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog

I used an ai coding agent to help me write parts of this and specifically the tests seem like they might be a bit overkill. I am open to suggestions if 100 lines of testing whether these env variables actually get passed from the settings constructor to the connection pool are really required.