### PR TITLE
Automatic and configurable keyword-index sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added configurable sort field remapping via `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` (items) and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` (collections).
+- Added file-based sort remap configuration via `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE` and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS_FILE`.
 - Added automatic keyword-sort remap detection for explicitly declared text fields with keyword subfields, including collection `title` mappings.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added configurable sort field remapping via `STAC_FASTAPI_SORT_FIELD_REMAPS` (global) and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` (collections-specific override).
+- Added configurable sort field remapping via `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` (items) and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` (collections).
 - Added automatic keyword-sort remap detection for explicitly declared text fields with keyword subfields, including collection `title` mappings.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added configurable sort field remapping via `STAC_FASTAPI_SORT_FIELD_REMAPS` (global) and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` (collections-specific override).
+
 ### Changed
+
+- Sort remap dictionaries are now computed once at application startup. For collection sorting, SFEOS can auto-detect keyword sort targets (for example `title` → `title.keyword`) from generated mappings when no explicit remap is provided.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added configurable sort field remapping via `STAC_FASTAPI_SORT_FIELD_REMAPS` (global) and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` (collections-specific override).
+- Added automatic keyword-sort remap detection for explicitly declared text fields with keyword subfields, including collection `title` mappings.
 
 ### Changed
 
-- Sort remap dictionaries are now computed once at application startup. For collection sorting, SFEOS can auto-detect keyword sort targets (for example `title` → `title.keyword`) from generated mappings when no explicit remap is provided.
+- Default collection title mappings now index `title` as `text` with a `title.keyword` subfield so collection titles are sortable without custom mapping.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ These extensions make it easier to build user interfaces that display and naviga
 >
 > **Important**: Adding keyword fields to make text fields sortable can significantly increase the index size, especially for large text fields. Consider the storage implications when deciding which fields to make sortable.
 
-> **Tip**: If you add a keyword subfield for sorting (for example `title.keyword`) through custom mappings, SFEOS can remap sort fields automatically at startup based on the generated mappings. You can also override this behavior explicitly with `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`. See [Sorting Text Fields with Keyword Subfields](#sorting-text-fields-with-keyword-subfields) for the full example.
+> **Tip**: If you add a keyword subfield for sorting (for example `title.keyword`) through custom mappings, SFEOS can remap sort fields automatically at startup based on the generated mappings. You can also override this behavior explicitly with `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` / `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE` and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` / `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS_FILE`. See [Sorting Text Fields with Keyword Subfields](#sorting-text-fields-with-keyword-subfields) for the full example.
 
 
 ## Catalogs Route
@@ -1092,8 +1092,10 @@ You can customize additional settings in your `.env` file:
 | `STAC_FASTAPI_ES_DYNAMIC_TEMPLATES_FILE` | Path to a JSON file containing custom Elasticsearch/OpenSearch dynamic template to merge with defaults. See [Custom Index Mappings](#custom-index-mappings). | `None` | Optional |
 | `STAC_FASTAPI_ES_DYNAMIC_MAPPING` | Controls dynamic mapping behavior for item indices. Values: `true` (default), `false`, or `strict`. See [Custom Index Mappings](#custom-index-mappings). | `true` | Optional |
 | `STAC_FASTAPI_ES_COLLECTIONS_DYNAMIC_MAPPING` | Controls dynamic mapping behavior for collection indices. Values: `true` (default), `false`, or `strict`. See [Custom Index Mappings](#custom-index-mappings). | `true` | Optional |
-| `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for item endpoints only. Example: `{"title":"title.keyword"}`. | `{}` | Optional |
+| `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for item endpoints only. Example: `{"properties.platform_name":"properties.platform_name.keyword"}`. | `{}` | Optional |
+| `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE` | Path to a JSON file containing sort field remaps for item endpoints only. Uses the same object format as `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS`. | `None` | Optional |
 | `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for collection endpoints only. Example: `{"title":"title.keyword"}`. | `{}` | Optional |
+| `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS_FILE` | Path to a JSON file containing sort field remaps for collection endpoints only. Uses the same object format as `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`. | `None` | Optional |
 | `STAC_FASTAPI_ES_COERCE_GLOBAL` | Sets the index-level coerce setting. When true (default), coercion is allowed (e.g., "10" → 10, 5.0 → 5). When false, coercion is disabled, documents with type mismatches are rejected unless overridden at the field level. | `true` | Optional |
 
 ### 7. Filtering, Exclusions & Queryables
@@ -1939,11 +1941,60 @@ Optional explicit remap override:
 export STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS='{"title":"title.keyword"}'
 ```
 
+Or use file-based configuration:
+
+```bash
+export STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS_FILE=/app/collections-sort-remaps.json
+```
+
 Remap resolution order is:
 
 1. `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`
-2. Auto-detection from generated mappings at startup
-3. Original sort field name
+2. `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS_FILE`
+3. Auto-detection from generated mappings at startup
+4. Original sort field name
+
+In practice, this is an ordered fallback with **OR** semantics between `VAR` and `FILE`:
+- If `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` is set and non-empty, it is used.
+- `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS_FILE` is only read when `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` is unset or empty.
+
+**Example - Item property under `properties.*` with file-based remap:**
+
+```bash
+export STAC_FASTAPI_ES_CUSTOM_MAPPINGS='{
+  "properties": {
+    "properties": {
+      "properties": {
+        "platform_name": {
+          "type": "text",
+          "fields": {
+            "keyword": {"type": "keyword"}
+          }
+        }
+      }
+    }
+  }
+}'
+
+cat > /app/items-sort-remaps.json <<EOF
+{
+  "properties.platform_name": "properties.platform_name.keyword"
+}
+EOF
+
+export STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE=/app/items-sort-remaps.json
+```
+
+For items, remap resolution order is:
+
+1. `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS`
+2. `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE`
+3. Auto-detection from generated mappings at startup
+4. Original sort field name
+
+In practice, this is an ordered fallback with **OR** semantics between `VAR` and `FILE`:
+- If `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` is set and non-empty, it is used.
+- `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE` is only read when `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` is unset or empty.
 
 **Example - Adding Cube Extension Fields:**
 

--- a/README.md
+++ b/README.md
@@ -241,11 +241,13 @@ These extensions make it easier to build user interfaces that display and naviga
 > - `extent.temporal.interval` (date field)
 > - `temporal` (alias to extent.temporal.interval)
 >
-> Text fields like `title` and `description` are not sortable by default as they use text analysis for better search capabilities. Attempting to sort on these fields will result in a user-friendly error message explaining which fields are sortable and how to make additional fields sortable by updating the mappings.
+> For collections, the default mapping also includes an explicit `title` field mapped as `text` with a `title.keyword` subfield, so title sorting works out of the box without extra custom mapping.
+>
+> Text fields like `description` are not sortable by default as they use text analysis for better search capabilities. Attempting to sort on these fields will result in a user-friendly error message explaining which fields are sortable and how to make additional fields sortable by updating the mappings.
 >
 > **Important**: Adding keyword fields to make text fields sortable can significantly increase the index size, especially for large text fields. Consider the storage implications when deciding which fields to make sortable.
 
-> **Tip**: If you add a keyword subfield for sorting (for example `title.keyword`) through custom mappings, SFEOS can remap sort fields automatically at startup based on the generated mappings. You can also override this behavior explicitly with `STAC_FASTAPI_SORT_FIELD_REMAPS` and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`.
+> **Tip**: If you add a keyword subfield for sorting (for example `title.keyword`) through custom mappings, SFEOS can remap sort fields automatically at startup based on the generated mappings. You can also override this behavior explicitly with `STAC_FASTAPI_SORT_FIELD_REMAPS` and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`. See [Sorting Text Fields with Keyword Subfields](#sorting-text-fields-with-keyword-subfields) for the full example.
 
 
 ## Catalogs Route

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ These extensions make it easier to build user interfaces that display and naviga
 >
 > **Important**: Adding keyword fields to make text fields sortable can significantly increase the index size, especially for large text fields. Consider the storage implications when deciding which fields to make sortable.
 
+> **Tip**: If you add a keyword subfield for sorting (for example `title.keyword`) through custom mappings, SFEOS can remap sort fields automatically at startup based on the generated mappings. You can also override this behavior explicitly with `STAC_FASTAPI_SORT_FIELD_REMAPS` and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`.
+
 
 ## Catalogs Route
 
@@ -1088,6 +1090,8 @@ You can customize additional settings in your `.env` file:
 | `STAC_FASTAPI_ES_DYNAMIC_TEMPLATES_FILE` | Path to a JSON file containing custom Elasticsearch/OpenSearch dynamic template to merge with defaults. See [Custom Index Mappings](#custom-index-mappings). | `None` | Optional |
 | `STAC_FASTAPI_ES_DYNAMIC_MAPPING` | Controls dynamic mapping behavior for item indices. Values: `true` (default), `false`, or `strict`. See [Custom Index Mappings](#custom-index-mappings). | `true` | Optional |
 | `STAC_FASTAPI_ES_COLLECTIONS_DYNAMIC_MAPPING` | Controls dynamic mapping behavior for collection indices. Values: `true` (default), `false`, or `strict`. See [Custom Index Mappings](#custom-index-mappings). | `true` | Optional |
+| `STAC_FASTAPI_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for all endpoints. Example: `{"title":"title.keyword"}`. | `{}` | Optional |
+| `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for collection endpoints only. Overrides `STAC_FASTAPI_SORT_FIELD_REMAPS` for collections. Example: `{"title":"title.keyword"}`. | `{}` | Optional |
 | `STAC_FASTAPI_ES_COERCE_GLOBAL` | Sets the index-level coerce setting. When true (default), coercion is allowed (e.g., "10" → 10, 5.0 → 5). When false, coercion is disabled, documents with type mismatches are rejected unless overridden at the field level. | `true` | Optional |
 
 ### 7. Filtering, Exclusions & Queryables
@@ -1907,6 +1911,38 @@ export STAC_FASTAPI_ES_CUSTOM_MAPPINGS='{
   }
 }'
 ```
+
+### Sorting Text Fields with Keyword Subfields
+
+If you need to sort on text fields such as `title`, create a keyword subfield via custom mappings and then use sort field remaps (or rely on startup auto-detection).
+
+**Example - Collection title as text + keyword:**
+
+```bash
+export STAC_FASTAPI_ES_COLLECTIONS_CUSTOM_MAPPINGS='{
+  "properties": {
+    "title": {
+      "type": "text",
+      "fields": {
+        "keyword": {"type": "keyword"}
+      }
+    }
+  }
+}'
+```
+
+Optional explicit remap override:
+
+```bash
+export STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS='{"title":"title.keyword"}'
+```
+
+Remap resolution order is:
+
+1. `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`
+2. `STAC_FASTAPI_SORT_FIELD_REMAPS`
+3. Auto-detection from generated mappings at startup
+4. Original sort field name
 
 **Example - Adding Cube Extension Fields:**
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ These extensions make it easier to build user interfaces that display and naviga
 >
 > **Important**: Adding keyword fields to make text fields sortable can significantly increase the index size, especially for large text fields. Consider the storage implications when deciding which fields to make sortable.
 
-> **Tip**: If you add a keyword subfield for sorting (for example `title.keyword`) through custom mappings, SFEOS can remap sort fields automatically at startup based on the generated mappings. You can also override this behavior explicitly with `STAC_FASTAPI_SORT_FIELD_REMAPS` and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`. See [Sorting Text Fields with Keyword Subfields](#sorting-text-fields-with-keyword-subfields) for the full example.
+> **Tip**: If you add a keyword subfield for sorting (for example `title.keyword`) through custom mappings, SFEOS can remap sort fields automatically at startup based on the generated mappings. You can also override this behavior explicitly with `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` and `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`. See [Sorting Text Fields with Keyword Subfields](#sorting-text-fields-with-keyword-subfields) for the full example.
 
 
 ## Catalogs Route
@@ -1092,8 +1092,8 @@ You can customize additional settings in your `.env` file:
 | `STAC_FASTAPI_ES_DYNAMIC_TEMPLATES_FILE` | Path to a JSON file containing custom Elasticsearch/OpenSearch dynamic template to merge with defaults. See [Custom Index Mappings](#custom-index-mappings). | `None` | Optional |
 | `STAC_FASTAPI_ES_DYNAMIC_MAPPING` | Controls dynamic mapping behavior for item indices. Values: `true` (default), `false`, or `strict`. See [Custom Index Mappings](#custom-index-mappings). | `true` | Optional |
 | `STAC_FASTAPI_ES_COLLECTIONS_DYNAMIC_MAPPING` | Controls dynamic mapping behavior for collection indices. Values: `true` (default), `false`, or `strict`. See [Custom Index Mappings](#custom-index-mappings). | `true` | Optional |
-| `STAC_FASTAPI_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for all endpoints. Example: `{"title":"title.keyword"}`. | `{}` | Optional |
-| `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for collection endpoints only. Overrides `STAC_FASTAPI_SORT_FIELD_REMAPS` for collections. Example: `{"title":"title.keyword"}`. | `{}` | Optional |
+| `STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for item endpoints only. Example: `{"title":"title.keyword"}`. | `{}` | Optional |
+| `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS` | JSON object mapping API sort fields to backend fields for collection endpoints only. Example: `{"title":"title.keyword"}`. | `{}` | Optional |
 | `STAC_FASTAPI_ES_COERCE_GLOBAL` | Sets the index-level coerce setting. When true (default), coercion is allowed (e.g., "10" → 10, 5.0 → 5). When false, coercion is disabled, documents with type mismatches are rejected unless overridden at the field level. | `true` | Optional |
 
 ### 7. Filtering, Exclusions & Queryables
@@ -1942,9 +1942,8 @@ export STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS='{"title":"title.keyword"}'
 Remap resolution order is:
 
 1. `STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS`
-2. `STAC_FASTAPI_SORT_FIELD_REMAPS`
-3. Auto-detection from generated mappings at startup
-4. Original sort field name
+2. Auto-detection from generated mappings at startup
+3. Original sort field name
 
 **Example - Adding Cube Extension Fields:**
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -66,6 +66,7 @@ from stac_fastapi.sfeos_helpers.database.catalogs import (
 from stac_fastapi.sfeos_helpers.database.query import (
     ES_MAX_URL_LENGTH,
     add_collections_to_body,
+    remap_sort_field_shared,
 )
 from stac_fastapi.sfeos_helpers.database.utils import (
     add_hidden_filter,
@@ -229,7 +230,9 @@ class DatabaseLogic(BaseDatabaseLogic):
         formatted_sort = []
         if sort:
             for item in sort:
-                field = item.get("field")
+                field = remap_sort_field_shared(
+                    item.get("field", ""), is_collection=True
+                )
                 direction = item.get("direction", "asc")
                 if field:
                     formatted_sort.append({field: {"order": direction}})

--- a/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
+++ b/stac_fastapi/opensearch/stac_fastapi/opensearch/database_logic.py
@@ -62,6 +62,7 @@ from stac_fastapi.sfeos_helpers.database.catalogs import (
 from stac_fastapi.sfeos_helpers.database.query import (
     ES_MAX_URL_LENGTH,
     add_collections_to_body,
+    remap_sort_field_shared,
 )
 from stac_fastapi.sfeos_helpers.database.utils import (
     add_hidden_filter,
@@ -228,7 +229,9 @@ class DatabaseLogic(BaseDatabaseLogic):
         formatted_sort = []
         if sort:
             for item in sort:
-                field = item.get("field")
+                field = remap_sort_field_shared(
+                    item.get("field", ""), is_collection=True
+                )
                 direction = item.get("direction", "asc")
                 if field:
                     formatted_sort.append({field: {"order": direction}})

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
@@ -78,12 +78,16 @@ def _detect_keyword_sort_remaps_from_mapping(
     return remaps
 
 
-MANUAL_SORT_FIELD_REMAPS = _parse_sort_field_remaps("STAC_FASTAPI_SORT_FIELD_REMAPS")
+MANUAL_ITEMS_SORT_FIELD_REMAPS = _parse_sort_field_remaps(
+    "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS"
+)
 MANUAL_COLLECTIONS_SORT_FIELD_REMAPS = _parse_sort_field_remaps(
     "STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS"
 )
 
-AUTO_SORT_FIELD_REMAPS = _detect_keyword_sort_remaps_from_mapping(ES_ITEMS_MAPPINGS)
+AUTO_ITEMS_SORT_FIELD_REMAPS = _detect_keyword_sort_remaps_from_mapping(
+    ES_ITEMS_MAPPINGS
+)
 AUTO_COLLECTIONS_SORT_FIELD_REMAPS = _detect_keyword_sort_remaps_from_mapping(
     ES_COLLECTIONS_MAPPINGS
 )
@@ -93,19 +97,17 @@ def remap_sort_field_shared(field_name: str, is_collection: bool = False) -> str
     """Remap API sort field names to engine fields via optional env config.
 
     Env vars (JSON objects):
-    - STAC_FASTAPI_SORT_FIELD_REMAPS
-    - STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS (overrides global for collections)
+    - STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS (items endpoints)
+    - STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS (collection endpoints)
     """
     if is_collection:
         if field_name in MANUAL_COLLECTIONS_SORT_FIELD_REMAPS:
             return MANUAL_COLLECTIONS_SORT_FIELD_REMAPS[field_name]
-        if field_name in MANUAL_SORT_FIELD_REMAPS:
-            return MANUAL_SORT_FIELD_REMAPS[field_name]
         return AUTO_COLLECTIONS_SORT_FIELD_REMAPS.get(field_name, field_name)
 
-    if field_name in MANUAL_SORT_FIELD_REMAPS:
-        return MANUAL_SORT_FIELD_REMAPS[field_name]
-    return AUTO_SORT_FIELD_REMAPS.get(field_name, field_name)
+    if field_name in MANUAL_ITEMS_SORT_FIELD_REMAPS:
+        return MANUAL_ITEMS_SORT_FIELD_REMAPS[field_name]
+    return AUTO_ITEMS_SORT_FIELD_REMAPS.get(field_name, field_name)
 
 
 def apply_free_text_filter_shared(

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
@@ -18,20 +18,38 @@ from stac_fastapi.sfeos_helpers.mappings import (
 ES_MAX_URL_LENGTH = int(os.getenv("ES_MAX_URL_LENGTH", "4096"))
 
 
-def _parse_sort_field_remaps(env_var: str) -> dict[str, str]:
-    """Parse sort field remaps from a JSON object environment variable."""
+def _parse_sort_field_remaps(
+    env_var: str, file_env_var: str | None = None
+) -> dict[str, str]:
+    """Parse sort field remaps from env JSON or optional *_FILE JSON.
+
+    Precedence is env_var first, then file_env_var.
+    """
     value = os.getenv(env_var)
+    source_name = env_var
+
+    if not value and file_env_var:
+        file_path = os.getenv(file_env_var)
+        if file_path:
+            try:
+                with open(file_path, encoding="utf-8") as f:
+                    value = f.read()
+                source_name = file_env_var
+            except OSError:
+                logging.warning("Could not read %s path: %s", file_env_var, file_path)
+                return {}
+
     if not value:
         return {}
 
     try:
         parsed = json.loads(value)
     except json.JSONDecodeError:
-        logging.warning("Invalid JSON in %s; expected an object.", env_var)
+        logging.warning("Invalid JSON in %s; expected an object.", source_name)
         return {}
 
     if not isinstance(parsed, dict):
-        logging.warning("Invalid value in %s; expected an object.", env_var)
+        logging.warning("Invalid value in %s; expected an object.", source_name)
         return {}
 
     remaps: dict[str, str] = {}
@@ -79,10 +97,12 @@ def _detect_keyword_sort_remaps_from_mapping(
 
 
 MANUAL_ITEMS_SORT_FIELD_REMAPS = _parse_sort_field_remaps(
-    "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS"
+    "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS",
+    "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE",
 )
 MANUAL_COLLECTIONS_SORT_FIELD_REMAPS = _parse_sort_field_remaps(
-    "STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS"
+    "STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS",
+    "STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS_FILE",
 )
 
 AUTO_ITEMS_SORT_FIELD_REMAPS = _detect_keyword_sort_remaps_from_mapping(
@@ -98,7 +118,9 @@ def remap_sort_field_shared(field_name: str, is_collection: bool = False) -> str
 
     Env vars (JSON objects):
     - STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS (items endpoints)
+    - STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE (items endpoints)
     - STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS (collection endpoints)
+    - STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS_FILE (collection endpoints)
     """
     if is_collection:
         if field_name in MANUAL_COLLECTIONS_SORT_FIELD_REMAPS:

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/database/query.py
@@ -3,14 +3,109 @@
 This module provides functions for building and manipulating Elasticsearch/OpenSearch queries.
 """
 
+import json
 import logging
 import os
 from typing import Any
 
 from stac_fastapi.core.utilities import bbox2polygon
-from stac_fastapi.sfeos_helpers.mappings import Geometry
+from stac_fastapi.sfeos_helpers.mappings import (
+    ES_COLLECTIONS_MAPPINGS,
+    ES_ITEMS_MAPPINGS,
+    Geometry,
+)
 
 ES_MAX_URL_LENGTH = int(os.getenv("ES_MAX_URL_LENGTH", "4096"))
+
+
+def _parse_sort_field_remaps(env_var: str) -> dict[str, str]:
+    """Parse sort field remaps from a JSON object environment variable."""
+    value = os.getenv(env_var)
+    if not value:
+        return {}
+
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        logging.warning("Invalid JSON in %s; expected an object.", env_var)
+        return {}
+
+    if not isinstance(parsed, dict):
+        logging.warning("Invalid value in %s; expected an object.", env_var)
+        return {}
+
+    remaps: dict[str, str] = {}
+    for key, mapped in parsed.items():
+        if isinstance(key, str) and isinstance(mapped, str) and key and mapped:
+            remaps[key] = mapped
+
+    return remaps
+
+
+def _detect_keyword_sort_remaps_from_mapping(
+    mapping: dict[str, Any],
+) -> dict[str, str]:
+    """Detect sortable keyword subfields from explicit mappings.
+
+    For a text field with a keyword multi-field, this returns a remap like:
+    {"title": "title.keyword"}
+    """
+    remaps: dict[str, str] = {}
+
+    def walk(path: str, field_def: dict[str, Any]) -> None:
+        field_type = field_def.get("type")
+        multi_fields = field_def.get("fields", {})
+
+        if field_type == "text" and isinstance(multi_fields, dict):
+            for sub_name, sub_def in multi_fields.items():
+                if isinstance(sub_def, dict) and sub_def.get("type") == "keyword":
+                    remaps.setdefault(path, f"{path}.{sub_name}")
+                    break
+
+        nested = field_def.get("properties")
+        if isinstance(nested, dict):
+            for child_name, child_def in nested.items():
+                if isinstance(child_def, dict):
+                    child_path = f"{path}.{child_name}" if path else child_name
+                    walk(child_path, child_def)
+
+    properties = mapping.get("properties", {})
+    if isinstance(properties, dict):
+        for field_name, field_def in properties.items():
+            if isinstance(field_def, dict):
+                walk(field_name, field_def)
+
+    return remaps
+
+
+MANUAL_SORT_FIELD_REMAPS = _parse_sort_field_remaps("STAC_FASTAPI_SORT_FIELD_REMAPS")
+MANUAL_COLLECTIONS_SORT_FIELD_REMAPS = _parse_sort_field_remaps(
+    "STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS"
+)
+
+AUTO_SORT_FIELD_REMAPS = _detect_keyword_sort_remaps_from_mapping(ES_ITEMS_MAPPINGS)
+AUTO_COLLECTIONS_SORT_FIELD_REMAPS = _detect_keyword_sort_remaps_from_mapping(
+    ES_COLLECTIONS_MAPPINGS
+)
+
+
+def remap_sort_field_shared(field_name: str, is_collection: bool = False) -> str:
+    """Remap API sort field names to engine fields via optional env config.
+
+    Env vars (JSON objects):
+    - STAC_FASTAPI_SORT_FIELD_REMAPS
+    - STAC_FASTAPI_COLLECTIONS_SORT_FIELD_REMAPS (overrides global for collections)
+    """
+    if is_collection:
+        if field_name in MANUAL_COLLECTIONS_SORT_FIELD_REMAPS:
+            return MANUAL_COLLECTIONS_SORT_FIELD_REMAPS[field_name]
+        if field_name in MANUAL_SORT_FIELD_REMAPS:
+            return MANUAL_SORT_FIELD_REMAPS[field_name]
+        return AUTO_COLLECTIONS_SORT_FIELD_REMAPS.get(field_name, field_name)
+
+    if field_name in MANUAL_SORT_FIELD_REMAPS:
+        return MANUAL_SORT_FIELD_REMAPS[field_name]
+    return AUTO_SORT_FIELD_REMAPS.get(field_name, field_name)
 
 
 def apply_free_text_filter_shared(
@@ -315,7 +410,9 @@ def apply_collections_bbox_filter_shared(
     }
 
 
-def populate_sort_shared(sortby: list) -> dict[str, dict[str, str]] | None:
+def populate_sort_shared(
+    sortby: list, is_collection: bool = False
+) -> dict[str, dict[str, str]] | None:
     """Create a sort configuration for Elasticsearch/OpenSearch queries.
 
     Args:
@@ -338,7 +435,7 @@ def populate_sort_shared(sortby: list) -> dict[str, dict[str, str]] | None:
     if sortby:
         sort_config = {}
         for s in sortby:
-            field_name = s.field
+            field_name = remap_sort_field_shared(s.field, is_collection=is_collection)
             direction = s.direction
             sort_obj = {"order": direction}
 

--- a/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
+++ b/stac_fastapi/sfeos_helpers/stac_fastapi/sfeos_helpers/mappings.py
@@ -408,6 +408,10 @@ _BASE_ES_COLLECTIONS_MAPPINGS = {
     "dynamic_templates": ES_MAPPINGS_DYNAMIC_TEMPLATES,
     "properties": {
         "id": {"type": "keyword"},
+        "title": {
+            "type": "text",
+            "fields": {"keyword": {"type": "keyword"}},
+        },
         "parent_ids": {"type": "keyword"},
         "bbox_shape": {"type": "geo_shape"},
         "extent.temporal.interval": {

--- a/stac_fastapi/tests/sfeos_helpers/test_sort_field_remaps.py
+++ b/stac_fastapi/tests/sfeos_helpers/test_sort_field_remaps.py
@@ -1,6 +1,7 @@
 import stac_fastapi.sfeos_helpers.database.query as query_module
 from stac_fastapi.sfeos_helpers.database.query import (
     _detect_keyword_sort_remaps_from_mapping,
+    _parse_sort_field_remaps,
     populate_sort_shared,
     remap_sort_field_shared,
 )
@@ -142,3 +143,60 @@ def test_collection_remap_does_not_fallback_to_items_manual(monkeypatch):
     monkeypatch.setattr(query_module, "AUTO_COLLECTIONS_SORT_FIELD_REMAPS", {})
 
     assert remap_sort_field_shared("title", is_collection=True) == "title"
+
+
+def test_parse_sort_field_remaps_from_file(monkeypatch, tmp_path):
+    remaps_file = tmp_path / "item-remaps.json"
+    remaps_file.write_text('{"title":"title.keyword"}', encoding="utf-8")
+
+    monkeypatch.delenv("STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS", raising=False)
+    monkeypatch.setenv("STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE", str(remaps_file))
+
+    parsed = _parse_sort_field_remaps(
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS",
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE",
+    )
+    assert parsed == {"title": "title.keyword"}
+
+
+def test_parse_sort_field_remaps_env_overrides_file(monkeypatch, tmp_path):
+    remaps_file = tmp_path / "item-remaps.json"
+    remaps_file.write_text('{"title":"title.from.file"}', encoding="utf-8")
+
+    monkeypatch.setenv(
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS", '{"title":"title.from.env"}'
+    )
+    monkeypatch.setenv("STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE", str(remaps_file))
+
+    parsed = _parse_sort_field_remaps(
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS",
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE",
+    )
+    assert parsed == {"title": "title.from.env"}
+
+
+def test_parse_sort_field_remaps_missing_file_is_ignored(monkeypatch):
+    monkeypatch.delenv("STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS", raising=False)
+    monkeypatch.setenv(
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE", "/tmp/does-not-exist-remaps.json"
+    )
+
+    parsed = _parse_sort_field_remaps(
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS",
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE",
+    )
+    assert parsed == {}
+
+
+def test_parse_sort_field_remaps_invalid_file_json_is_ignored(monkeypatch, tmp_path):
+    remaps_file = tmp_path / "invalid-remaps.json"
+    remaps_file.write_text("not-json", encoding="utf-8")
+
+    monkeypatch.delenv("STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS", raising=False)
+    monkeypatch.setenv("STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE", str(remaps_file))
+
+    parsed = _parse_sort_field_remaps(
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS",
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS_FILE",
+    )
+    assert parsed == {}

--- a/stac_fastapi/tests/sfeos_helpers/test_sort_field_remaps.py
+++ b/stac_fastapi/tests/sfeos_helpers/test_sort_field_remaps.py
@@ -1,0 +1,135 @@
+import stac_fastapi.sfeos_helpers.database.query as query_module
+from stac_fastapi.sfeos_helpers.database.query import (
+    _detect_keyword_sort_remaps_from_mapping,
+    populate_sort_shared,
+    remap_sort_field_shared,
+)
+
+
+class _SortField:
+    def __init__(self, field: str, direction: str = "asc"):
+        self.field = field
+        self.direction = direction
+
+
+def test_remap_sort_field_shared_global(monkeypatch):
+    monkeypatch.setattr(
+        query_module,
+        "MANUAL_SORT_FIELD_REMAPS",
+        {"title": "title.keyword"},
+    )
+    monkeypatch.setattr(query_module, "AUTO_SORT_FIELD_REMAPS", {})
+
+    assert remap_sort_field_shared("title") == "title.keyword"
+    assert remap_sort_field_shared("id") == "id"
+
+
+def test_remap_sort_field_shared_collections_override(monkeypatch):
+    monkeypatch.setattr(
+        query_module,
+        "MANUAL_SORT_FIELD_REMAPS",
+        {"title": "global_title.keyword"},
+    )
+    monkeypatch.setattr(
+        query_module,
+        "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS",
+        {"title": "title.keyword"},
+    )
+
+    assert remap_sort_field_shared("title", is_collection=True) == "title.keyword"
+
+
+def test_remap_sort_field_shared_invalid_json_is_ignored(monkeypatch):
+    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "AUTO_SORT_FIELD_REMAPS", {})
+
+    assert remap_sort_field_shared("title") == "title"
+
+
+def test_populate_sort_shared_applies_collection_remap(monkeypatch):
+    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(
+        query_module,
+        "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS",
+        {"title": "title.keyword"},
+    )
+    monkeypatch.setattr(query_module, "AUTO_COLLECTIONS_SORT_FIELD_REMAPS", {})
+
+    sort = populate_sort_shared([_SortField("title", "asc")], is_collection=True)
+
+    assert "title.keyword" in sort
+    assert sort["title.keyword"]["order"] == "asc"
+    assert "id" in sort
+
+
+def test_populate_sort_shared_default_without_remap(monkeypatch):
+    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "AUTO_COLLECTIONS_SORT_FIELD_REMAPS", {})
+
+    sort = populate_sort_shared([_SortField("title", "asc")], is_collection=True)
+
+    assert "title" in sort
+    assert "title.keyword" not in sort
+
+
+def test_detect_keyword_sort_remaps_from_mapping():
+    mapping = {
+        "properties": {
+            "title": {
+                "type": "text",
+                "fields": {"keyword": {"type": "keyword"}},
+            },
+            "description": {"type": "text"},
+            "nested": {
+                "properties": {
+                    "label": {
+                        "type": "text",
+                        "fields": {"raw": {"type": "keyword"}},
+                    }
+                }
+            },
+        }
+    }
+
+    remaps = _detect_keyword_sort_remaps_from_mapping(mapping)
+
+    assert remaps["title"] == "title.keyword"
+    assert remaps["nested.label"] == "nested.label.raw"
+    assert "description" not in remaps
+
+
+def test_remap_sort_field_shared_uses_auto_detection_for_collections(monkeypatch):
+    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(
+        query_module,
+        "AUTO_COLLECTIONS_SORT_FIELD_REMAPS",
+        {"title": "title.keyword"},
+    )
+
+    assert remap_sort_field_shared("title", is_collection=True) == "title.keyword"
+
+
+def test_manual_collection_remap_overrides_auto_detection(monkeypatch):
+    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(
+        query_module,
+        "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS",
+        {"title": "title.sort"},
+    )
+    monkeypatch.setattr(
+        query_module,
+        "AUTO_COLLECTIONS_SORT_FIELD_REMAPS",
+        {"title": "title.keyword"},
+    )
+
+    assert remap_sort_field_shared("title", is_collection=True) == "title.sort"
+
+
+def test_env_changes_after_import_do_not_change_remaps(monkeypatch):
+    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "AUTO_SORT_FIELD_REMAPS", {})
+    monkeypatch.setenv("STAC_FASTAPI_SORT_FIELD_REMAPS", '{"title":"title.keyword"}')
+
+    assert remap_sort_field_shared("title") == "title"

--- a/stac_fastapi/tests/sfeos_helpers/test_sort_field_remaps.py
+++ b/stac_fastapi/tests/sfeos_helpers/test_sort_field_remaps.py
@@ -15,21 +15,16 @@ class _SortField:
 def test_remap_sort_field_shared_global(monkeypatch):
     monkeypatch.setattr(
         query_module,
-        "MANUAL_SORT_FIELD_REMAPS",
+        "MANUAL_ITEMS_SORT_FIELD_REMAPS",
         {"title": "title.keyword"},
     )
-    monkeypatch.setattr(query_module, "AUTO_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "AUTO_ITEMS_SORT_FIELD_REMAPS", {})
 
     assert remap_sort_field_shared("title") == "title.keyword"
     assert remap_sort_field_shared("id") == "id"
 
 
-def test_remap_sort_field_shared_collections_override(monkeypatch):
-    monkeypatch.setattr(
-        query_module,
-        "MANUAL_SORT_FIELD_REMAPS",
-        {"title": "global_title.keyword"},
-    )
+def test_remap_sort_field_shared_collections_manual_remap(monkeypatch):
     monkeypatch.setattr(
         query_module,
         "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS",
@@ -40,14 +35,14 @@ def test_remap_sort_field_shared_collections_override(monkeypatch):
 
 
 def test_remap_sort_field_shared_invalid_json_is_ignored(monkeypatch):
-    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
-    monkeypatch.setattr(query_module, "AUTO_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "MANUAL_ITEMS_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "AUTO_ITEMS_SORT_FIELD_REMAPS", {})
 
     assert remap_sort_field_shared("title") == "title"
 
 
 def test_populate_sort_shared_applies_collection_remap(monkeypatch):
-    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "MANUAL_ITEMS_SORT_FIELD_REMAPS", {})
     monkeypatch.setattr(
         query_module,
         "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS",
@@ -63,7 +58,7 @@ def test_populate_sort_shared_applies_collection_remap(monkeypatch):
 
 
 def test_populate_sort_shared_default_without_remap(monkeypatch):
-    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "MANUAL_ITEMS_SORT_FIELD_REMAPS", {})
     monkeypatch.setattr(query_module, "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS", {})
     monkeypatch.setattr(query_module, "AUTO_COLLECTIONS_SORT_FIELD_REMAPS", {})
 
@@ -100,7 +95,7 @@ def test_detect_keyword_sort_remaps_from_mapping():
 
 
 def test_remap_sort_field_shared_uses_auto_detection_for_collections(monkeypatch):
-    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "MANUAL_ITEMS_SORT_FIELD_REMAPS", {})
     monkeypatch.setattr(query_module, "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS", {})
     monkeypatch.setattr(
         query_module,
@@ -112,7 +107,7 @@ def test_remap_sort_field_shared_uses_auto_detection_for_collections(monkeypatch
 
 
 def test_manual_collection_remap_overrides_auto_detection(monkeypatch):
-    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "MANUAL_ITEMS_SORT_FIELD_REMAPS", {})
     monkeypatch.setattr(
         query_module,
         "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS",
@@ -128,8 +123,22 @@ def test_manual_collection_remap_overrides_auto_detection(monkeypatch):
 
 
 def test_env_changes_after_import_do_not_change_remaps(monkeypatch):
-    monkeypatch.setattr(query_module, "MANUAL_SORT_FIELD_REMAPS", {})
-    monkeypatch.setattr(query_module, "AUTO_SORT_FIELD_REMAPS", {})
-    monkeypatch.setenv("STAC_FASTAPI_SORT_FIELD_REMAPS", '{"title":"title.keyword"}')
+    monkeypatch.setattr(query_module, "MANUAL_ITEMS_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "AUTO_ITEMS_SORT_FIELD_REMAPS", {})
+    monkeypatch.setenv(
+        "STAC_FASTAPI_ITEMS_SORT_FIELD_REMAPS", '{"title":"title.keyword"}'
+    )
 
     assert remap_sort_field_shared("title") == "title"
+
+
+def test_collection_remap_does_not_fallback_to_items_manual(monkeypatch):
+    monkeypatch.setattr(
+        query_module,
+        "MANUAL_ITEMS_SORT_FIELD_REMAPS",
+        {"title": "items_title.keyword"},
+    )
+    monkeypatch.setattr(query_module, "MANUAL_COLLECTIONS_SORT_FIELD_REMAPS", {})
+    monkeypatch.setattr(query_module, "AUTO_COLLECTIONS_SORT_FIELD_REMAPS", {})
+
+    assert remap_sort_field_shared("title", is_collection=True) == "title"

--- a/uv.lock
+++ b/uv.lock
@@ -2469,15 +2469,15 @@ wheels = [
 
 [[package]]
 name = "stac-fastapi-api"
-version = "6.6.0"
+version = "6.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "brotli-asgi" },
     { name = "stac-fastapi-types" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/a8/2f2f4a883ec42620a294a28026e3a3affeca9c695fb80f09026ced29a8b8/stac_fastapi_api-6.6.0.tar.gz", hash = "sha256:7cbbadbc85976c6b97f9c4a80895a894aeca13d9926bb8b70078b6ea69e7f619", size = 12996, upload-time = "2026-08-31T12:39:01.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/2c/55c823b5d4801452901c7a00648b997de68a47b8e62390b1331702b35110/stac_fastapi_api-6.5.0.tar.gz", hash = "sha256:9d40cc9604400d34b4001574842efe527129b66966d56254ed28f04df626e4d8", size = 13038, upload-time = "2026-08-03T15:26:54.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/24/be8f34369c9b5f54d52107ad472d56acd9d99396c181a3379e901af7589a/stac_fastapi_api-6.6.0-py3-none-any.whl", hash = "sha256:b65d3aa2264af9e49bbc962593529701d3db90e2a801db961161557542319204", size = 15724, upload-time = "2026-08-31T12:39:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/73/66/b18187b4939d9b541f02b9b92fcd21b7760fad9696b67bc6d74404684ecb/stac_fastapi_api-6.5.0-py3-none-any.whl", hash = "sha256:06c8269eb3022b1cadb184d913ed48c447e718af780e4108a7f3bd7dbed7a183", size = 15796, upload-time = "2026-08-03T15:26:55.486Z" },
 ]
 
 [[package]]
@@ -2549,10 +2549,10 @@ requires-dist = [
     { name = "retry", marker = "extra == 'redis'", specifier = "~=0.9.2" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.49,<2.69" },
     { name = "slowapi", specifier = "~=0.1.9" },
-    { name = "stac-fastapi-api", specifier = "==6.6.0" },
+    { name = "stac-fastapi-api", specifier = "==6.5.0" },
     { name = "stac-fastapi-catalogs-extension", marker = "extra == 'catalogs'", specifier = "==0.5.0" },
-    { name = "stac-fastapi-extensions", specifier = "==6.6.0" },
-    { name = "stac-fastapi-types", specifier = "==6.6.0" },
+    { name = "stac-fastapi-extensions", specifier = "==6.5.0" },
+    { name = "stac-fastapi-types", specifier = "==6.5.0" },
     { name = "stac-pydantic", specifier = ">=3.3,<3.7" },
     { name = "stac-valid", marker = "extra == 'validator'", specifier = ">=4.2.2,<4.6.0" },
     { name = "starlette", specifier = ">=0.35.0,<1.7.0" },
@@ -2630,15 +2630,15 @@ provides-extras = ["catalogs", "dev", "docs", "redis", "server", "validator"]
 
 [[package]]
 name = "stac-fastapi-extensions"
-version = "6.6.0"
+version = "6.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "stac-fastapi-api" },
     { name = "stac-fastapi-types" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ad/cd791021daa0a5d62ede920c4d60b0aa0c265e75ea3cd66ae05af6da3fb7/stac_fastapi_extensions-6.6.0.tar.gz", hash = "sha256:34c020eb1b0b431230306d2a073a06d57583f4f701569b11103b12fda3e0ea0f", size = 18859, upload-time = "2026-08-31T12:38:59.796Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/e7e393f8a63ace152d27f5e609d574b50c32843e0d77238b33bd53c7a862/stac_fastapi_extensions-6.5.0.tar.gz", hash = "sha256:b0f2da75769825d1e3ff20f87601abe22f5e197e3fc650f1db2d33a4efb086e1", size = 18858, upload-time = "2026-08-03T15:26:53.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/5e/1099b07a0fe9bfaa7e23ac808cd34594c63e3728001855265dea41d7c292/stac_fastapi_extensions-6.6.0-py3-none-any.whl", hash = "sha256:df066b19e6e28181826ab5ec7481b13f8f7e14b00f9331f56e8f84a4bdbd17a1", size = 36533, upload-time = "2026-08-31T12:38:58.851Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/0c/c34409274efba13361f494e6f5f68f6dda0601157242f90a90cc61e5de7b/stac_fastapi_extensions-6.5.0-py3-none-any.whl", hash = "sha256:e18248c08daa8519d83ae026acf0fc988f08f5fa430b1d3eccd49415864b7bf1", size = 36535, upload-time = "2026-08-03T15:26:52.327Z" },
 ]
 
 [[package]]
@@ -2708,7 +2708,7 @@ provides-extras = ["catalogs", "dev", "docs", "redis", "server", "validator"]
 
 [[package]]
 name = "stac-fastapi-types"
-version = "6.6.0"
+version = "6.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2718,9 +2718,9 @@ dependencies = [
     { name = "stac-pydantic" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/f6a0e77820357f273f69e8b6930010a27ecf806a22a05e4f684e8bc878ce/stac_fastapi_types-6.6.0.tar.gz", hash = "sha256:607243f14dc8eddad157fd6e9e9716eb344e9c2bd0a1f02dcbf279806d029eac", size = 11118, upload-time = "2026-08-31T12:38:56.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/c1/bb01e08a1f4b25cc7f6e0ebf985cf4e28e2d1df700f5375533bb48067db4/stac_fastapi_types-6.5.0.tar.gz", hash = "sha256:31083ead8a53b950570e71628323fec627e3c090eb3a0ca29213fecd13845ea4", size = 11118, upload-time = "2026-08-03T15:26:51.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/d5/8c0457b024a6af84ce030628ee995578732fe1847ddefe20bcbf476db707/stac_fastapi_types-6.6.0-py3-none-any.whl", hash = "sha256:fdfea762a2bc5931a9bd0cf2bd0998c464ea37e657a7ffd67595f064a07ce014", size = 14080, upload-time = "2026-08-31T12:38:57.05Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e8/c9fadf7eac8b19a7b60cc884d674faccc5afe37e81e3dda97e58afe2d32a/stac_fastapi_types-6.5.0-py3-none-any.whl", hash = "sha256:25e04fa99c08acc7794bf1e14743219df3367e2c6216401de53748d16a3e881d", size = 14081, upload-time = "2026-08-03T15:26:50.096Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2469,15 +2469,15 @@ wheels = [
 
 [[package]]
 name = "stac-fastapi-api"
-version = "6.5.0"
+version = "6.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "brotli-asgi" },
     { name = "stac-fastapi-types" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/2c/55c823b5d4801452901c7a00648b997de68a47b8e62390b1331702b35110/stac_fastapi_api-6.5.0.tar.gz", hash = "sha256:9d40cc9604400d34b4001574842efe527129b66966d56254ed28f04df626e4d8", size = 13038, upload-time = "2026-08-03T15:26:54.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/a8/2f2f4a883ec42620a294a28026e3a3affeca9c695fb80f09026ced29a8b8/stac_fastapi_api-6.6.0.tar.gz", hash = "sha256:7cbbadbc85976c6b97f9c4a80895a894aeca13d9926bb8b70078b6ea69e7f619", size = 12996, upload-time = "2026-08-31T12:39:01.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/66/b18187b4939d9b541f02b9b92fcd21b7760fad9696b67bc6d74404684ecb/stac_fastapi_api-6.5.0-py3-none-any.whl", hash = "sha256:06c8269eb3022b1cadb184d913ed48c447e718af780e4108a7f3bd7dbed7a183", size = 15796, upload-time = "2026-08-03T15:26:55.486Z" },
+    { url = "https://files.pythonhosted.org/packages/95/24/be8f34369c9b5f54d52107ad472d56acd9d99396c181a3379e901af7589a/stac_fastapi_api-6.6.0-py3-none-any.whl", hash = "sha256:b65d3aa2264af9e49bbc962593529701d3db90e2a801db961161557542319204", size = 15724, upload-time = "2026-08-31T12:39:02.038Z" },
 ]
 
 [[package]]
@@ -2549,10 +2549,10 @@ requires-dist = [
     { name = "retry", marker = "extra == 'redis'", specifier = "~=0.9.2" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.49,<2.69" },
     { name = "slowapi", specifier = "~=0.1.9" },
-    { name = "stac-fastapi-api", specifier = "==6.5.0" },
+    { name = "stac-fastapi-api", specifier = "==6.6.0" },
     { name = "stac-fastapi-catalogs-extension", marker = "extra == 'catalogs'", specifier = "==0.5.0" },
-    { name = "stac-fastapi-extensions", specifier = "==6.5.0" },
-    { name = "stac-fastapi-types", specifier = "==6.5.0" },
+    { name = "stac-fastapi-extensions", specifier = "==6.6.0" },
+    { name = "stac-fastapi-types", specifier = "==6.6.0" },
     { name = "stac-pydantic", specifier = ">=3.3,<3.7" },
     { name = "stac-valid", marker = "extra == 'validator'", specifier = ">=4.2.2,<4.6.0" },
     { name = "starlette", specifier = ">=0.35.0,<1.7.0" },
@@ -2630,15 +2630,15 @@ provides-extras = ["catalogs", "dev", "docs", "redis", "server", "validator"]
 
 [[package]]
 name = "stac-fastapi-extensions"
-version = "6.5.0"
+version = "6.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "stac-fastapi-api" },
     { name = "stac-fastapi-types" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/e7e393f8a63ace152d27f5e609d574b50c32843e0d77238b33bd53c7a862/stac_fastapi_extensions-6.5.0.tar.gz", hash = "sha256:b0f2da75769825d1e3ff20f87601abe22f5e197e3fc650f1db2d33a4efb086e1", size = 18858, upload-time = "2026-08-03T15:26:53.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/ad/cd791021daa0a5d62ede920c4d60b0aa0c265e75ea3cd66ae05af6da3fb7/stac_fastapi_extensions-6.6.0.tar.gz", hash = "sha256:34c020eb1b0b431230306d2a073a06d57583f4f701569b11103b12fda3e0ea0f", size = 18859, upload-time = "2026-08-31T12:38:59.796Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/0c/c34409274efba13361f494e6f5f68f6dda0601157242f90a90cc61e5de7b/stac_fastapi_extensions-6.5.0-py3-none-any.whl", hash = "sha256:e18248c08daa8519d83ae026acf0fc988f08f5fa430b1d3eccd49415864b7bf1", size = 36535, upload-time = "2026-08-03T15:26:52.327Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5e/1099b07a0fe9bfaa7e23ac808cd34594c63e3728001855265dea41d7c292/stac_fastapi_extensions-6.6.0-py3-none-any.whl", hash = "sha256:df066b19e6e28181826ab5ec7481b13f8f7e14b00f9331f56e8f84a4bdbd17a1", size = 36533, upload-time = "2026-08-31T12:38:58.851Z" },
 ]
 
 [[package]]
@@ -2708,7 +2708,7 @@ provides-extras = ["catalogs", "dev", "docs", "redis", "server", "validator"]
 
 [[package]]
 name = "stac-fastapi-types"
-version = "6.5.0"
+version = "6.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2718,9 +2718,9 @@ dependencies = [
     { name = "stac-pydantic" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/c1/bb01e08a1f4b25cc7f6e0ebf985cf4e28e2d1df700f5375533bb48067db4/stac_fastapi_types-6.5.0.tar.gz", hash = "sha256:31083ead8a53b950570e71628323fec627e3c090eb3a0ca29213fecd13845ea4", size = 11118, upload-time = "2026-08-03T15:26:51.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/f6a0e77820357f273f69e8b6930010a27ecf806a22a05e4f684e8bc878ce/stac_fastapi_types-6.6.0.tar.gz", hash = "sha256:607243f14dc8eddad157fd6e9e9716eb344e9c2bd0a1f02dcbf279806d029eac", size = 11118, upload-time = "2026-08-31T12:38:56.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/e8/c9fadf7eac8b19a7b60cc884d674faccc5afe37e81e3dda97e58afe2d32a/stac_fastapi_types-6.5.0-py3-none-any.whl", hash = "sha256:25e04fa99c08acc7794bf1e14743219df3367e2c6216401de53748d16a3e881d", size = 14081, upload-time = "2026-08-03T15:26:50.096Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d5/8c0457b024a6af84ce030628ee995578732fe1847ddefe20bcbf476db707/stac_fastapi_types-6.6.0-py3-none-any.whl", hash = "sha256:fdfea762a2bc5931a9bd0cf2bd0998c464ea37e657a7ffd67595f064a07ce014", size = 14080, upload-time = "2026-08-31T12:38:57.05Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.139.2"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -674,9 +674,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -2469,15 +2469,15 @@ wheels = [
 
 [[package]]
 name = "stac-fastapi-api"
-version = "6.5.0"
+version = "6.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "brotli-asgi" },
     { name = "stac-fastapi-types" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/2c/55c823b5d4801452901c7a00648b997de68a47b8e62390b1331702b35110/stac_fastapi_api-6.5.0.tar.gz", hash = "sha256:9d40cc9604400d34b4001574842efe527129b66966d56254ed28f04df626e4d8", size = 13038, upload-time = "2026-08-03T15:26:54.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/a8/2f2f4a883ec42620a294a28026e3a3affeca9c695fb80f09026ced29a8b8/stac_fastapi_api-6.6.0.tar.gz", hash = "sha256:7cbbadbc85976c6b97f9c4a80895a894aeca13d9926bb8b70078b6ea69e7f619", size = 12996, upload-time = "2026-08-31T12:39:01.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/66/b18187b4939d9b541f02b9b92fcd21b7760fad9696b67bc6d74404684ecb/stac_fastapi_api-6.5.0-py3-none-any.whl", hash = "sha256:06c8269eb3022b1cadb184d913ed48c447e718af780e4108a7f3bd7dbed7a183", size = 15796, upload-time = "2026-08-03T15:26:55.486Z" },
+    { url = "https://files.pythonhosted.org/packages/95/24/be8f34369c9b5f54d52107ad472d56acd9d99396c181a3379e901af7589a/stac_fastapi_api-6.6.0-py3-none-any.whl", hash = "sha256:b65d3aa2264af9e49bbc962593529701d3db90e2a801db961161557542319204", size = 15724, upload-time = "2026-08-31T12:39:02.038Z" },
 ]
 
 [[package]]
@@ -2549,10 +2549,10 @@ requires-dist = [
     { name = "retry", marker = "extra == 'redis'", specifier = "~=0.9.2" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.49,<2.69" },
     { name = "slowapi", specifier = "~=0.1.9" },
-    { name = "stac-fastapi-api", specifier = "==6.5.0" },
+    { name = "stac-fastapi-api", specifier = "==6.6.0" },
     { name = "stac-fastapi-catalogs-extension", marker = "extra == 'catalogs'", specifier = "==0.5.0" },
-    { name = "stac-fastapi-extensions", specifier = "==6.5.0" },
-    { name = "stac-fastapi-types", specifier = "==6.5.0" },
+    { name = "stac-fastapi-extensions", specifier = "==6.6.0" },
+    { name = "stac-fastapi-types", specifier = "==6.6.0" },
     { name = "stac-pydantic", specifier = ">=3.3,<3.7" },
     { name = "stac-valid", marker = "extra == 'validator'", specifier = ">=4.2.2,<4.6.0" },
     { name = "starlette", specifier = ">=0.35.0,<1.7.0" },
@@ -2630,15 +2630,15 @@ provides-extras = ["catalogs", "dev", "docs", "redis", "server", "validator"]
 
 [[package]]
 name = "stac-fastapi-extensions"
-version = "6.5.0"
+version = "6.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "stac-fastapi-api" },
     { name = "stac-fastapi-types" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/e7e393f8a63ace152d27f5e609d574b50c32843e0d77238b33bd53c7a862/stac_fastapi_extensions-6.5.0.tar.gz", hash = "sha256:b0f2da75769825d1e3ff20f87601abe22f5e197e3fc650f1db2d33a4efb086e1", size = 18858, upload-time = "2026-08-03T15:26:53.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/ad/cd791021daa0a5d62ede920c4d60b0aa0c265e75ea3cd66ae05af6da3fb7/stac_fastapi_extensions-6.6.0.tar.gz", hash = "sha256:34c020eb1b0b431230306d2a073a06d57583f4f701569b11103b12fda3e0ea0f", size = 18859, upload-time = "2026-08-31T12:38:59.796Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/0c/c34409274efba13361f494e6f5f68f6dda0601157242f90a90cc61e5de7b/stac_fastapi_extensions-6.5.0-py3-none-any.whl", hash = "sha256:e18248c08daa8519d83ae026acf0fc988f08f5fa430b1d3eccd49415864b7bf1", size = 36535, upload-time = "2026-08-03T15:26:52.327Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5e/1099b07a0fe9bfaa7e23ac808cd34594c63e3728001855265dea41d7c292/stac_fastapi_extensions-6.6.0-py3-none-any.whl", hash = "sha256:df066b19e6e28181826ab5ec7481b13f8f7e14b00f9331f56e8f84a4bdbd17a1", size = 36533, upload-time = "2026-08-31T12:38:58.851Z" },
 ]
 
 [[package]]
@@ -2708,7 +2708,7 @@ provides-extras = ["catalogs", "dev", "docs", "redis", "server", "validator"]
 
 [[package]]
 name = "stac-fastapi-types"
-version = "6.5.0"
+version = "6.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2718,9 +2718,9 @@ dependencies = [
     { name = "stac-pydantic" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/c1/bb01e08a1f4b25cc7f6e0ebf985cf4e28e2d1df700f5375533bb48067db4/stac_fastapi_types-6.5.0.tar.gz", hash = "sha256:31083ead8a53b950570e71628323fec627e3c090eb3a0ca29213fecd13845ea4", size = 11118, upload-time = "2026-08-03T15:26:51.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/f6a0e77820357f273f69e8b6930010a27ecf806a22a05e4f684e8bc878ce/stac_fastapi_types-6.6.0.tar.gz", hash = "sha256:607243f14dc8eddad157fd6e9e9716eb344e9c2bd0a1f02dcbf279806d029eac", size = 11118, upload-time = "2026-08-31T12:38:56.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/e8/c9fadf7eac8b19a7b60cc884d674faccc5afe37e81e3dda97e58afe2d32a/stac_fastapi_types-6.5.0-py3-none-any.whl", hash = "sha256:25e04fa99c08acc7794bf1e14743219df3367e2c6216401de53748d16a3e881d", size = 14081, upload-time = "2026-08-03T15:26:50.096Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d5/8c0457b024a6af84ce030628ee995578732fe1847ddefe20bcbf476db707/stac_fastapi_types-6.6.0-py3-none-any.whl", hash = "sha256:fdfea762a2bc5931a9bd0cf2bd0998c464ea37e657a7ffd67595f064a07ce014", size = 14080, upload-time = "2026-08-31T12:38:57.05Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Related Issue(s):**

- #818 

**Description:**

Adds configurable sort-field remapping and defaults collection `title` to `text` + `title.keyword` so collection titles are sortable without custom mapping, while preserving explicit override support and auto-detection for mapped keyword subfields.

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] Changes are added to the changelog